### PR TITLE
Add a VPC module

### DIFF
--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -21,12 +21,6 @@ module "vpc" {
   public_subnets  = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 2, 2)]
   private_subnets = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 1, 0)]
   intra_subnets   = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 3, 6)]
-  public_subnet_ipv6_prefixes  = [for k, v in local.azs : k]
-  private_subnet_ipv6_prefixes = [for k, v in local.azs : k + 2]
-  intra_subnet_ipv6_prefixes   = [for k, v in local.azs : k + 4]
-
-  enable_ipv6                                   = true
-  public_subnet_assign_ipv6_address_on_creation = true
 
   enable_dns_hostnames   = true
   enable_dns_support     = true

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,4 +1,6 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+}
 
 locals {
   azs = slice(data.aws_availability_zones.available.names, 0, 2)

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -23,6 +23,12 @@ module "vpc" {
   public_subnets  = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 2, 2)]
   private_subnets = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 1, 0)]
   intra_subnets   = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 3, 6)]
+  public_subnet_ipv6_prefixes  = [for k, v in local.azs : k]
+  private_subnet_ipv6_prefixes = [for k, v in local.azs : k + 2]
+  intra_subnet_ipv6_prefixes   = [for k, v in local.azs : k + 4]
+
+  enable_ipv6                                   = true
+  public_subnet_assign_ipv6_address_on_creation = true
 
   enable_dns_hostnames   = true
   enable_dns_support     = true

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,69 @@
+data "aws_availability_zones" "available" {}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+  subnet_cidrs = [for k, v in local.azs : cidrsubnet(var.cidr, 1, k)]
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = var.name
+  cidr = var.cidr
+
+  azs = local.azs
+  # 1/2 of address space for each AZ
+  # within AZ:
+  # 1/2 for private
+  # 1/4 for public
+  # 1/8 for intra
+  # 1/8 spare
+  public_subnets  = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 2, 2)]
+  private_subnets = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 1, 0)]
+  intra_subnets   = [for cidr in local.subnet_cidrs : cidrsubnet(cidr, 3, 6)]
+  public_subnet_ipv6_prefixes  = [for k, v in local.azs : k]
+  private_subnet_ipv6_prefixes = [for k, v in local.azs : k + 2]
+  intra_subnet_ipv6_prefixes   = [for k, v in local.azs : k + 4]
+
+  enable_ipv6                                   = true
+  public_subnet_assign_ipv6_address_on_creation = true
+
+  enable_dns_hostnames   = true
+  enable_dns_support     = true
+  enable_nat_gateway     = true
+  one_nat_gateway_per_az = true
+}
+
+module "api_gateway_security_group" {
+  source = "terraform-aws-modules/security-group/aws"
+
+  create = var.internal
+
+  name = "${var.name}-api-gateway"
+  description = "All inbound HTTPS traffic for the API Gateway Endpoint"
+  vpc_id = module.vpc.vpc_id
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+  ingress_rules       = ["https-443-tcp"]
+}
+
+module "vpc_endpoints" {
+  source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+
+  vpc_id             = module.vpc.vpc_id
+  security_group_ids = [module.api_gateway_security_group.security_group_id]
+
+  endpoints = {
+    s3 = {
+      service         = "s3"
+      service_type    = "Gateway"
+      route_table_ids = concat(module.vpc.public_route_table_ids, module.vpc.private_route_table_ids)
+    },
+    api = {
+      service             = "execute-api"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.private_subnets
+      create              = var.internal
+    },
+  }
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -30,6 +30,11 @@ module "vpc" {
   enable_ipv6                                   = true
   public_subnet_assign_ipv6_address_on_creation = true
 
+  # Disable DNS64. We don't need it, and it breaks IPv4-only services like VPC endpoints.
+  public_subnet_enable_dns64  = false
+  private_subnet_enable_dns64 = false
+  intra_subnet_enable_dns64   = false
+
   enable_dns_hostnames   = true
   enable_dns_support     = true
   enable_nat_gateway     = true

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc" {
+  description = "VPC"
+  value       = module.vpc
+}
+
+output "api_endpoint" {
+  description = "API Gateway VPC endpoint (if internal=true)"
+  value       = var.internal ? module.vpc_endpoints.endpoints["api"] : null
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type     = string
+  nullable = false
+}
+
+variable "cidr" {
+  type     = string
+  nullable = false
+}
+
+variable "internal" {
+  type     = bool
+  nullable = false
+}


### PR DESCRIPTION
It creates three sets of subnets, an S3 VPC endpoint, and (for internal VPCs) an API Gateway endpoint