### PR TITLE
Require version < 6.0.0 for the RDS module

### DIFF
--- a/terraform/modules/db/main.tf
+++ b/terraform/modules/db/main.tf
@@ -30,6 +30,7 @@ module "db_security_group" {
 
 module "db" {
   source = "terraform-aws-modules/rds/aws"
+  version = "< 6.0.0"
 
   identifier = var.identifier
 


### PR DESCRIPTION
Version 6.0.0 is removing passwords and encouraging the use of the Secrets Manager