### PR TITLE
Validate name variable further

### DIFF
--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -5,8 +5,8 @@ variable "name" {
   nullable    = false
   description = "Name to use for the VPC, DB, and CloudFormation stack, as well as a prefix for other resources"
   validation {
-    condition     = length(var.name) <= 20
-    error_message = "Name too long for downstream resources like bucket_prefix"
+    condition     = length(var.name) <= 20 && can(regex("^[a-z0-9-]+$", var.name))
+    error_message = "Lowercase alphanumerics and hyphens; no longer than 20 characters."
   }
 }
 


### PR DESCRIPTION
Ensure lower alphanum and hyphens to prevent downstream errors like the following; e.g. if user uses a `.` or `_` in `name`:

```
│ Error: only lowercase alphanumeric characters and hyphens allowed in "identifier"
│ 
│   with module.quilt.module.db.module.db.module.db_instance.aws_db_instance.this[0],
│   on .terraform/modules/quilt.db.db/modules/db_instance/main.tf line 34, in resource "aws_db_instance" "this":
│   34:   identifier        = local.identifier
│ 
╵
╷
│ Error: invalid value for domain_name (must start with a lowercase alphabet and be at least 3 and no more than 28 characters long. Valid characters are a-z (lowercase letters), 0-9, and - (hyphen).)
│ 
│   with module.quilt.module.search.aws_elasticsearch_domain.search,
│   on .terraform/modules/quilt/modules/search/main.tf line 32, in resource "aws_elasticsearch_domain" "search":
│   32:   domain_name = var.domain_name
│ 
```