### PR TITLE
Add var for EBS IOPS to support gp3 disk for search

### DIFF
--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -56,6 +56,7 @@ module "search" {
   zone_awareness_enabled   = var.search_zone_awareness_enabled
   volume_size              = var.search_volume_size
   volume_type              = var.search_volume_type
+  volume_iops              = var.search_volume_iops
 }
 
 resource "random_password" "admin_password" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -105,6 +105,13 @@ variable "search_zone_awareness_enabled" {
   description = "Whether to enable Multi-AZ for the ElasticSearch cluster"
 }
 
+variable "search_volume_iops" {
+  type        = number
+  nullable    = false
+  default     = null
+  description = "EBS IOPS (required for gp3 volumes: 9,216 - 16,000) "
+}
+
 variable "search_volume_size" {
   type        = number
   nullable    = false

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -107,6 +107,7 @@ variable "search_zone_awareness_enabled" {
 
 variable "search_volume_iops" {
   type        = number
+  nullable    = true
   default     = null
   description = "EBS IOPS (required for gp3 volumes: 9,216 - 16,000) "
 }

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -107,7 +107,6 @@ variable "search_zone_awareness_enabled" {
 
 variable "search_volume_iops" {
   type        = number
-  nullable    = true
   default     = null
   description = "EBS IOPS (required for gp3 volumes: 9,216 - 16,000) "
 }

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -107,7 +107,6 @@ variable "search_zone_awareness_enabled" {
 
 variable "search_volume_iops" {
   type        = number
-  nullable    = false
   default     = null
   description = "EBS IOPS (required for gp3 volumes: 9,216 - 16,000) "
 }

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -1,13 +1,13 @@
 module "search_accessor_security_group" {
   source = "terraform-aws-modules/security-group/aws"
 
-  name = "${var.domain_name}-search-accessor"
+  name        = "${var.domain_name}-search-accessor"
   description = "For resources that need access to search cluster"
-  vpc_id = var.vpc_id
+  vpc_id      = var.vpc_id
 
   egress_with_source_security_group_id = [
     {
-      rule = "https-443-tcp"
+      rule                     = "https-443-tcp"
       source_security_group_id = module.search_security_group.security_group_id
     }
   ]
@@ -16,20 +16,20 @@ module "search_accessor_security_group" {
 module "search_security_group" {
   source = "terraform-aws-modules/security-group/aws"
 
-  name = "${var.domain_name}-search"
+  name        = "${var.domain_name}-search"
   description = "For search cluster resources"
-  vpc_id = var.vpc_id
+  vpc_id      = var.vpc_id
 
   ingress_with_source_security_group_id = [
     {
-      rule = "https-443-tcp"
+      rule                     = "https-443-tcp"
       source_security_group_id = module.search_accessor_security_group.security_group_id
     }
   ]
 }
 
 resource "aws_elasticsearch_domain" "search" {
-  domain_name = var.domain_name
+  domain_name           = var.domain_name
   elasticsearch_version = "6.7"
 
   auto_tune_options {
@@ -51,6 +51,7 @@ resource "aws_elasticsearch_domain" "search" {
     ebs_enabled = true
     volume_size = var.volume_size
     volume_type = var.volume_type
+    iops        = var.volume_iops
   }
 
   encrypt_at_rest {

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -50,10 +50,10 @@ variable "zone_awareness_enabled" {
 
 variable "volume_iops" {
   type        = number
-  description = "The IOPS for the volume. This must be either null or an integer greater than or equal to 3000."
+  description = "Must be null or an integer greater than or equal to 3000."
   validation {
     condition     = var.volume_iops == null || var.volume_iops >= 3000
-    error_message = "Must be null or an integer greater than or equal to 3000."
+    error_message = "Invalid volume_iops"
   }
 }
 

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -48,6 +48,11 @@ variable "zone_awareness_enabled" {
   nullable = false
 }
 
+variable "volume_iops" {
+  type    = number
+  default = null
+}
+
 variable "volume_size" {
   type     = number
   nullable = false

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -49,7 +49,12 @@ variable "zone_awareness_enabled" {
 }
 
 variable "volume_iops" {
-  type = number
+  type        = number
+  description = "The IOPS for the volume. This must be either null or an integer greater than or equal to 3000."
+  validation {
+    condition     = var.volume_iops == null || var.volume_iops >= 3000
+    error_message = "Must be null or an integer greater than or equal to 3000."
+  }
 }
 
 variable "volume_size" {

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -49,8 +49,7 @@ variable "zone_awareness_enabled" {
 }
 
 variable "volume_iops" {
-  type    = number
-  default = null
+  type = number
 }
 
 variable "volume_size" {


### PR DESCRIPTION
Without this `apply` fails:

```
╷
│ Error: updating Elasticsearch Domain (arn:aws:es:us-west-2:060758809828:domain/apksearch) config: LimitExceededException: IOPS must be between 9216 and 16000
│ 
│   with module.quilt.module.search.aws_elasticsearch_domain.search,
│   on .terraform/modules/quilt/modules/search/main.tf line 31, in resource "aws_elasticsearch_domain" "search":
│   31: resource "aws_elasticsearch_domain" "search" {
│ 
```