### PR TITLE
Bump default data node EBS to max

### DIFF
--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -115,7 +115,7 @@ variable "search_volume_size" {
   type        = number
   nullable    = false
   default     = 512
-  description = "Size of EBS volume attached to each data node in the ElasticSearch cluster"
+  description = "Size (GiB) of EBS volume attached to each data node in the ElasticSearch cluster"
 }
 
 variable "search_volume_throughput" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -114,8 +114,8 @@ variable "search_volume_iops" {
 variable "search_volume_size" {
   type        = number
   nullable    = false
-  default     = 100
-  description = "Size of EBS volumes attached to data nodes in the ElasticSearch cluster"
+  default     = 512
+  description = "Size of EBS volume(s) attached to data nodes in the ElasticSearch cluster"
 }
 
 variable "search_volume_throughput" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -114,7 +114,7 @@ variable "search_volume_iops" {
 variable "search_volume_size" {
   type        = number
   nullable    = false
-  default     = 512
+  default     = 1024
   description = "Size (GiB) of EBS volume attached to each data node in the ElasticSearch cluster"
 }
 

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -115,7 +115,7 @@ variable "search_volume_size" {
   type        = number
   nullable    = false
   default     = 512
-  description = "Size of EBS volume(s) attached to data nodes in the ElasticSearch cluster"
+  description = "Size of EBS volume attached to each data node in the ElasticSearch cluster"
 }
 
 variable "search_volume_throughput" {


### PR DESCRIPTION
* Matches CloudFormation logic
* Gives customer better price/perf

This is the right default cluster:
```
search_dedicated_master_enabled = true
search_zone_awareness_enabled = true
search_instance_count = 2
search_instance_type = "m5.xlarge.elasticsearch"
search_volume_size = 1024
```