### PR TITLE
Correct required prefix size

### DIFF
--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -153,7 +153,7 @@ variable "vpc_id" {
 variable "api_endpoint" {
   type        = string
   default     = null
-  description = "VPC endpoint for API Gateway (api-execute) for Quilt services."
+  description = "VPC endpoint ID for API Gateway (api-execute) for Quilt services."
 
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -13,10 +13,10 @@ locals {
     "vpc_id (required)" : var.existing_vpc_id != null,
     "intra_subnets (required)" : var.existing_intra_subnets != null,
     "private_subnets (required)" : var.existing_private_subnets != null,
-    "public_subnets (required if var.internal == false)" : var.internal == (var.existing_public_subnets == null),
+    "public_subnets (required if var.internal == false, else must be null)" : var.internal == (var.existing_public_subnets == null),
     "user_security_group (required)" : var.existing_user_security_group != null,
-    "user_subnets (required if var.internal == true)" : var.internal == (var.existing_user_subnets != null)
-    "api_endpoint (required if var.internal == true)" : var.internal == (var.existing_api_endpoint != null),
+    "user_subnets (required if var.internal == true, else must be null)" : var.internal == (var.existing_user_subnets != null)
+    "api_endpoint (required if var.internal == true, else must be null)" : var.internal == (var.existing_api_endpoint != null),
   }
   new_network_requires = {
     "create_new_vpc == true" : var.create_new_vpc == true,

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -13,7 +13,7 @@ variable "cidr" {
   type     = string
   nullable = false
   validation {
-    condition     = split("/", var.cidr)[1] < 21
+    condition     = split("/", var.cidr)[1] < 22
     error_message = "cidr prefix should allow for at least 1,024 IP addresses"
   }
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -14,7 +14,7 @@ variable "cidr" {
   nullable = false
   validation {
     condition     = split("/", var.cidr)[1] < 22
-    error_message = "cidr prefix should allow for at least 1,024 IP addresses"
+    error_message = "CIDR prefix should allow for at least 1,024 IP addresses"
   }
 }
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -13,7 +13,7 @@ variable "cidr" {
   type     = string
   nullable = false
   validation {
-    condition     = split("/", var.cidr)[1] < 22
+    condition     = split("/", var.cidr)[1] <= 22
     error_message = "CIDR prefix should allow for at least 1,024 IP addresses"
   }
 }


### PR DESCRIPTION
Specify that `api_endpoint` is an id.