### PR TITLE
increase stack delete timeout from default 30m to 1h

### DIFF
--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -126,4 +126,8 @@ resource "aws_cloudformation_stack" "stack" {
       AdminPassword = random_password.admin_password.result
     }
   )
+
+  timeouts {
+    delete = "1h"
+  }
 }


### PR DESCRIPTION
Currently stack deletion timeouts sometimes.