### PR TITLE
Rectify user_subnet description, validation

### DIFF
--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -95,7 +95,7 @@ resource "aws_cloudformation_stack" "stack" {
      * If ECS tries to reach ECR before private subnet NAT is available then ECS fails. */
     module.vpc,
   ]
-  capabilities = ["CAPABILITY_NAMED_IAM"]
+  capabilities      = ["CAPABILITY_NAMED_IAM"]
   notification_arns = var.stack_notification_arns
 
   parameters = merge(

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -191,7 +191,7 @@ variable "user_security_group" {
 variable "user_subnets" {
   type        = list(string)
   default     = null
-  description = "Subnet IDs for Quilt load balancer. Only needed when var.internal == true and var.create_new_vpc == true."
+  description = "Subnet IDs for Quilt load balancer. Only needed when var.internal == true and var.create_new_vpc == false."
 }
 
 variable "stack_notification_arns" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -15,7 +15,7 @@ locals {
     "private_subnets (required)" : var.existing_private_subnets != null,
     "public_subnets (required if var.internal == false, else must be null)" : var.internal == (var.existing_public_subnets == null),
     "user_security_group (required)" : var.existing_user_security_group != null,
-    "user_subnets (required if var.internal == true and var.create_new_vpc == false, else must be null)" : var.internal && !var.create_new_vpc == (var.existing_user_subnets != null)
+    "user_subnets (required if var.internal == true and var.create_new_vpc == false, else must be null)" : (var.internal && !var.create_new_vpc) == (var.existing_user_subnets != null)
     "api_endpoint (required if var.internal == true, else must be null)" : var.internal == (var.existing_api_endpoint != null),
   }
   new_network_requires = {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -15,7 +15,7 @@ locals {
     "private_subnets (required)" : var.existing_private_subnets != null,
     "public_subnets (required if var.internal == false, else must be null)" : var.internal == (var.existing_public_subnets == null),
     "user_security_group (required)" : var.existing_user_security_group != null,
-    "user_subnets (required if var.internal == true, else must be null)" : var.internal == (var.existing_user_subnets != null)
+    "user_subnets (required if var.internal == true and var.create_new_vpc == false, else must be null)" : var.internal && !var.create_new_vpc == (var.existing_user_subnets != null)
     "api_endpoint (required if var.internal == true, else must be null)" : var.internal == (var.existing_api_endpoint != null),
   }
   new_network_requires = {


### PR DESCRIPTION
See [this key line of code](https://github.com/quiltdata/iac/blob/2fae8b98c43174e8b34f63157ce2217cdb0c86a1/modules/vpc/outputs.tf#L48). It is consistent with what we do in CloudFormation in that UserSubnets as a param is only ever exposed for `existing_vpc && elb_scheme == internal`. We have no choice (or at least it doesn't make much sense) to not use the PublicSubnets in the outward ALB case. Ditto for `!existing_vpc`.