### PR TITLE
Don't touch `auto_tune_options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ tfplan
 > ```
 
 If you encounter the above error we suggest that you use the latest version of the
-current repo which now no longer uses an `auto_tune_options` configuration
-block in the `search` module. We further recommend that you only use [search
-instance types that support Auto-Tune](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html)
+current repo which no longer uses an `auto_tune_options` configuration block in
+the `search` module. We further recommend that you only use
+[search instances that support Auto-Tune](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html)
 as the AWS service may automatically enable Auto-Tune without cause and without warning,
 leading to search domains that are difficult to upgrade.
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ tfplan
 > ```
 
 If you encounter the above error we suggest that you use the latest version of the
-current repo which now no longer sets an `auto_tune_configuration`
+current repo which now no longer uses an `auto_tune_options` configuration
 block in the `search` module. We further recommend that you only use [search
 instance types that support Auto-Tune](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html)
 as the AWS service may automatically enable Auto-Tune without cause and without warning,

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ tfplan
 > [remote state](https://developer.hashicorp.com/terraform/language/state/remote)
 > so that no passwords are checked into version control.
 
-
 # Known issues
 ## Elasticsearch ValidationException
 > ```

--- a/README.md
+++ b/README.md
@@ -15,20 +15,6 @@ See [examples/main.tf](examples/main.tf) for a starting point.
 ### Provider
 The `aws_elasticsearch_domain` called by the `quilt` module requires the
 5.20.0 provider version.
-
-```hcl
-provider "aws" {
-    version = "= 5.20.0"
-}
-```
-
-Pinning the provider version avoids the following error:
-> ```
-> Error: updating Elasticsearch Domain (arn:aws:es:foo:bar/baz) config:
-> ValidationException: A change/update is in progress. Please wait for it to
-> complete before requesting another change.
-> ```
-
 ### Profile
 You may wish to set a specific AWS profile before executing `terraform`
 commands. 
@@ -231,6 +217,31 @@ tfplan
 > [remote state](https://developer.hashicorp.com/terraform/language/state/remote)
 > so that no passwords are checked into version control.
 
+
+# Known issues
+
+## Elasticsearch ValidationException
+> ```
+> Error: updating Elasticsearch Domain (arn:aws:es:foo:bar/baz) config:
+> ValidationException: A change/update is in progress. Please wait for it to
+> complete before requesting another change.
+> ```
+
+If you encounter the above error we suggest that you use the latest version of the
+current repo which now no longer sets an `auto_tune_configuration`
+block in the `search` module. We further recommend that you only use [search
+instance types that support Auto-Tune](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html)
+as the AWS service may automatically enable Auto-Tune without cause and without warning,
+leading to search domains that are difficult to upgrade.
+
+Some users have overcome the above error by pinning the provider to 5.20.0 as shown
+below but this is not recommended given that 5.20.0 is an older version.
+
+```hcl
+provider "aws" {
+    version = "= 5.20.0"
+}
+```
 
 # References
 1. [Terraform: AWS Provider Tutorial](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/aws-build)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Deploy and maintain Quilt stacks with Terraform
-
 ## Prerequisites
-
 ### [Install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-
 
 ### Get a Terraform-compatible CloudFormation template
 You must use a specially configured Terraform-compatible Quilt CloudFormation
@@ -15,6 +12,7 @@ See [examples/main.tf](examples/main.tf) for a starting point.
 ### Provider
 The `aws_elasticsearch_domain` called by the `quilt` module requires the
 5.20.0 provider version.
+
 ### Profile
 You may wish to set a specific AWS profile before executing `terraform`
 commands. 
@@ -124,7 +122,6 @@ search_volume_throughput = 1187
 As a rule, `terraform apply` is sufficient to both deploy and update Quilt.
 
 ### Verify the plan
-
 Before calling `apply` read `terraform plan` carefully to ensure that it does
 not inadvertently destroy and recreate the stack. The following modifications
 are known to cause issues (see [examples/main.tf](examples/main.tf) for context).
@@ -219,7 +216,6 @@ tfplan
 
 
 # Known issues
-
 ## Elasticsearch ValidationException
 > ```
 > Error: updating Elasticsearch Domain (arn:aws:es:foo:bar/baz) config:

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -32,12 +32,6 @@ resource "aws_elasticsearch_domain" "search" {
   domain_name           = var.domain_name
   elasticsearch_version = "6.7"
 
-  auto_tune_options {
-    desired_state = var.auto_tune_desired_state
-    # https://github.com/hashicorp/terraform-provider-aws/issues/25712
-    rollback_on_disable = "DEFAULT_ROLLBACK"
-  }
-
   cluster_config {
     instance_count           = var.instance_count
     instance_type            = var.instance_type


### PR DESCRIPTION
The search module used auto_tune_options to prevent problematic forced and irreversible upgrades of unsupported instances but:
* We don't recommend such instances any longer (and the search configs reflect that)
* Terraform doesn't seem to mind applying from a module that contained the auto_tune_options block to one that does not and, if it succeeded in the first place auto-tune must be off and we don't have to worry about its rollback state machine