### PR TITLE
Remove bad provider pin in example

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version             = "= 5.20.0"
   allowed_account_ids = [""]
   region              = ""
   default_tags {

--- a/modules/cnames/main.tf
+++ b/modules/cnames/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"  # specify the version according to your requirement
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
(and delete an extraneous comment).

As documented in our README we no longer require nor recommend this pin, therefore it should not be in our examples/main.tf.