### PR TITLE
Increase default CFN stack update timeout from 30m to 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Optional release notice.
 - [Verb] Change description ([#<PR-number>](https://github.com/quiltdata/iac/pull/<PR-number>))
 -->
 
+## [Unreleased] - YYYY-MM-DD
+
+Optional release notice.
+
+- [Changed] Increase CFN stack update timeout from 30m to 1h ([#73](https://github.com/quiltdata/iac/pull/73))
+
 ## [1.0.0] - 2024-12-09
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Optional release notice.
 
 Optional release notice.
 
-- [Changed] Increase CFN stack update timeout from 30m to 1h ([#73](https://github.com/quiltdata/iac/pull/73))
+- [Changed] Increase CloudFormation stack update timeout from 30m to 1h ([#73](https://github.com/quiltdata/iac/pull/73))
 
 ## [1.0.0] - 2024-12-09
 

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -215,7 +215,7 @@ variable "delete_timeout" {
 variable "update_timeout" {
   description = "aws_cloudformation_stack.timeouts.update="
   type        = string
-  default     = "30m"
+  default     = "1h"
 }
 
 variable "on_failure" {


### PR DESCRIPTION
## Description

we encountered that timeout when molecule lambda was removed

## TODO

- [x] changelog