### PR TITLE
Revert "Update Postgres to 15.10 (#72)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
-To update to this version, version 1.0.0 must be deployed first.
+Optional release notice.
 
-- [Changed] Update Postgres to 15.10 ([#72](https://github.com/quiltdata/iac/pull/72))
 - [Changed] Increase CloudFormation stack update timeout from 30m to 1h ([#73](https://github.com/quiltdata/iac/pull/73))
 
 ## [1.0.0] - 2024-12-09

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -39,7 +39,7 @@ module "db" {
   engine                      = "postgres"
   allow_major_version_upgrade = true
   auto_minor_version_upgrade  = false
-  engine_version              = "15.10"
+  engine_version              = "15.7"
   storage_type                = "gp2"
   allocated_storage           = 100
   storage_encrypted           = true


### PR DESCRIPTION
This reverts commit 7ddddf6d54ef52f1ad1eb29cd7e7720eb56896c9.

## Description

I'm not really sure what approach we should use and updating to 15.10 won't allow us (currently) to upgrade to default 16 version. I'm giving up until (at least) the next release.

## TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry
