### PR TITLE
Really use on_failure variable, add on_failure to lifecycle.ignore_change so old stacks are not replaced

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,4 @@
 <!-- Remove items that are irrelevant to this PR -->
 
 - [ ] [CHANGELOG](../tree/main/CHANGELOG.md) entry
+- [ ] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Optional release notice.
 Optional release notice.
 
 - [Fixed] Really use `on_failure` variable, previously CloudFormation stack `on_failure` was hardcoded to `ROLLBACK` ([#77](https://github.com/quiltdata/iac/pull/77))
-- [Fixed] Add CloudFormation stack `on_failure` to `lifecycle.ignore_changes`, so stacks created before 0ca3e1319cc89557ea31b3553012562d0e9a0b81 won't be re-created on update by default ([#77](https://github.com/quiltdata/iac/pull/77))
+- [Fixed] Add CloudFormation stack `on_failure` to `lifecycle.ignore_changes`, so stacks created before [`0ca3e1319cc89557ea31b3553012562d0e9a0b81`](https://github.com/quiltdata/iac/commit/0ca3e1319cc89557ea31b3553012562d0e9a0b81) won't be re-created on update by default ([#77](https://github.com/quiltdata/iac/pull/77))
 - [Changed] Update Elasticsearch to 6.8 ([#71](https://github.com/quiltdata/iac/pull/71))
 - [Changed] Increase CloudFormation stack update timeout from 30m to 1h ([#73](https://github.com/quiltdata/iac/pull/73))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Optional release notice.
 
 Optional release notice.
 
+- [Fixed] Really use `on_failure` variable, previously CloudFormation stack `on_failure` was hardcoded to `ROLLBACK` ([#77](https://github.com/quiltdata/iac/pull/77))
+- [Fixed] Add CloudFormation stack `on_failure` to `lifecycle.ignore_changes`, so stacks created before 0ca3e1319cc89557ea31b3553012562d0e9a0b81 won't be re-created on update by default ([#77](https://github.com/quiltdata/iac/pull/77))
 - [Changed] Update Elasticsearch to 6.8 ([#71](https://github.com/quiltdata/iac/pull/71))
 - [Changed] Increase CloudFormation stack update timeout from 30m to 1h ([#73](https://github.com/quiltdata/iac/pull/73))
 

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -135,9 +135,9 @@ resource "aws_cloudformation_stack" "stack" {
 
   # on_failure = "ROLLBACK"
 
-  lifecycle {
-    ignore_changes = [
-      on_failure,
-    ]
-  }
+  # lifecycle {
+  #   ignore_changes = [
+  #     on_failure,
+  #   ]
+  # }
 }

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -133,5 +133,11 @@ resource "aws_cloudformation_stack" "stack" {
     create = var.create_timeout
   }
 
-  on_failure = "ROLLBACK"
+  # on_failure = "ROLLBACK"
+
+  lifecycle {
+    ignore_changes = [
+      on_failure,
+    ]
+  }
 }

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -135,9 +135,9 @@ resource "aws_cloudformation_stack" "stack" {
 
   # on_failure = "ROLLBACK"
 
-  # lifecycle {
-  #   ignore_changes = [
-  #     on_failure,
-  #   ]
-  # }
+  lifecycle {
+    ignore_changes = [
+      on_failure,
+    ]
+  }
 }

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -133,7 +133,7 @@ resource "aws_cloudformation_stack" "stack" {
     create = var.create_timeout
   }
 
-  # on_failure = "ROLLBACK"
+  on_failure = var.on_failure
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Description

as I understand `on_failure` is available only for [`CreateStack`](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html) operation, but not for [`UpdateStack`](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html) 
so to "modify" this option terraform has to re-create the stack :grinning:
(see https://github.com/hashicorp/terraform-provider-aws/issues/1807#issuecomment-335761995)

at first I was going to simply remove `on_failure` from our tf module as a fix because
1. it feels safe
2. as I understand it conflicts with [disable_rollback](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack#disable_rollback-1) option which could be useful for stack updates (we might want to use it in the future) and I *think* modifying it won't cause stack to be re-created

but if someone already created a stack using this problematic commit removing `on_failure` will cause their stack to be re-created
so the fix is to add `on_failure` to [lifecycle.ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes)
(but we still can choose to remove `on_failure`)

I think there is another option: set `on_failure` variable default to `null` and tell users who deployed using problematic commit to set it to `ROLLBACK`

## TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry
- [x] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*
