### PR TITLE
Increase default CFN stack delete timeout from 1h to 1h30m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Optional release notice.
 
 Optional release notice.
 
-- [Changed] Increase CloudFormation stack delete timeout from 1h to 1h30m ([#78](https://github.com/quiltdata/iac/pull/78))
+- [Changed] Increase default CloudFormation stack delete timeout from 1h to 1h30m ([#78](https://github.com/quiltdata/iac/pull/78))
 - [Fixed] Really use `on_failure` variable, previously CloudFormation stack `on_failure` was hardcoded to `ROLLBACK` ([#77](https://github.com/quiltdata/iac/pull/77))
 - [Fixed] Add CloudFormation stack `on_failure` to `lifecycle.ignore_changes`, so stacks created before [`0ca3e1319cc89557ea31b3553012562d0e9a0b81`](https://github.com/quiltdata/iac/commit/0ca3e1319cc89557ea31b3553012562d0e9a0b81) won't be re-created on update by default ([#77](https://github.com/quiltdata/iac/pull/77))
 - [Changed] Update Elasticsearch to 6.8 ([#71](https://github.com/quiltdata/iac/pull/71))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Optional release notice.
 
 Optional release notice.
 
+- [Changed] Increase CloudFormation stack delete timeout from 1h to 1h30m ([#78](https://github.com/quiltdata/iac/pull/78))
 - [Fixed] Really use `on_failure` variable, previously CloudFormation stack `on_failure` was hardcoded to `ROLLBACK` ([#77](https://github.com/quiltdata/iac/pull/77))
 - [Fixed] Add CloudFormation stack `on_failure` to `lifecycle.ignore_changes`, so stacks created before [`0ca3e1319cc89557ea31b3553012562d0e9a0b81`](https://github.com/quiltdata/iac/commit/0ca3e1319cc89557ea31b3553012562d0e9a0b81) won't be re-created on update by default ([#77](https://github.com/quiltdata/iac/pull/77))
 - [Changed] Update Elasticsearch to 6.8 ([#71](https://github.com/quiltdata/iac/pull/71))

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -209,7 +209,7 @@ variable "create_timeout" {
 variable "delete_timeout" {
   description = "aws_cloudformation_stack.timeouts.delete="
   type        = string
-  default     = "1h"
+  default     = "1h30m"
 }
 
 variable "update_timeout" {


### PR DESCRIPTION
## Description

## TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry
- [x] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*
