### PR TITLE
Add cost tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .terraform
 tfplan
+modules/db/main.tf
+tests/.terraform.tfstate.lock.info
+tests/terraform.tfstate.backup

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -5,6 +5,8 @@ module "db_accessor_security_group" {
   description = "For resources that need access to DB"
   vpc_id      = var.vpc_id
 
+  tags = local.stack_dependent_tags
+
   egress_with_source_security_group_id = [
     {
       rule                     = "postgresql-tcp"
@@ -19,6 +21,8 @@ module "db_security_group" {
   name        = "${var.identifier}-db"
   description = "For DB resources"
   vpc_id      = var.vpc_id
+
+  tags = local.stack_dependent_tags
 
   ingress_with_source_security_group_id = [
     {

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -6,7 +6,6 @@ module "db_accessor_security_group" {
   description = "For resources that need access to DB"
   vpc_id      = var.vpc_id
 
-  tags = var.tags
 
   egress_with_source_security_group_id = [
     {

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,3 +1,7 @@
+locals {
+  stack_dependent_tags = {}
+}
+
 module "db_accessor_security_group" {
   source = "terraform-aws-modules/security-group/aws"
 

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,6 +1,3 @@
-locals {
-  stack_dependent_tags = {}
-}
 
 module "db_accessor_security_group" {
   source = "terraform-aws-modules/security-group/aws"
@@ -9,7 +6,7 @@ module "db_accessor_security_group" {
   description = "For resources that need access to DB"
   vpc_id      = var.vpc_id
 
-  tags = local.stack_dependent_tags
+  tags = var.tags
 
   egress_with_source_security_group_id = [
     {
@@ -26,7 +23,7 @@ module "db_security_group" {
   description = "For DB resources"
   vpc_id      = var.vpc_id
 
-  tags = local.stack_dependent_tags
+  tags = var.tags
 
   ingress_with_source_security_group_id = [
     {
@@ -70,4 +67,5 @@ module "db" {
 
   backup_retention_period = 7
   deletion_protection     = var.deletion_protection
+  tags                   = var.tags
 }

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -41,3 +41,9 @@ variable "deletion_protection" {
   type     = bool
   nullable = false
 }
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/quilt/locals.tf
+++ b/modules/quilt/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  # Common tags to be applied to all resources
+  common_tags = {
+    "quilt:stack-name" = var.name
+    # Stack ID will be added after stack creation for resources that depend on the stack
+  }
+
+  # Tags that include the stack ID, for resources created after the CloudFormation stack
+  stack_dependent_tags = {
+    "quilt:stack-name" = var.name
+    "quilt:stack-id"   = aws_cloudformation_stack.stack.id
+  }
+}

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -70,6 +70,8 @@ resource "aws_s3_bucket" "cft_bucket" {
 
   # Nothing valuable in this bucket, so make the cleanup easier.
   force_destroy = true
+
+  tags = local.common_tags
 }
 
 resource "aws_s3_bucket_versioning" "cft_bucket_versioning" {
@@ -89,6 +91,8 @@ resource "aws_s3_object" "cft" {
 resource "aws_cloudformation_stack" "stack" {
   name         = var.name
   template_url = local.template_url
+
+  tags = local.common_tags
   depends_on = [
     aws_s3_object.cft,
     /* Prevent races between module.vpc and module.quilt resources. For example:

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -38,7 +38,6 @@ module "db" {
   instance_class      = var.db_instance_class
   multi_az            = var.db_multi_az
   deletion_protection = var.db_deletion_protection
-  tags               = local.stack_dependent_tags
 }
 
 module "search" {
@@ -60,7 +59,6 @@ module "search" {
   volume_type              = var.search_volume_type
   volume_iops              = var.search_volume_iops
   volume_throughput        = var.search_volume_throughput
-  tags                     = local.stack_dependent_tags
 }
 
 resource "random_password" "admin_password" {

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -15,7 +15,6 @@ module "vpc" {
   internal = var.internal
 
   create_new_vpc               = var.create_new_vpc
-  tags                         = local.stack_dependent_tags
   existing_api_endpoint        = var.api_endpoint
   existing_vpc_id              = var.vpc_id
   existing_intra_subnets       = var.intra_subnets

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -15,6 +15,7 @@ module "vpc" {
   internal = var.internal
 
   create_new_vpc               = var.create_new_vpc
+  tags                         = local.stack_dependent_tags
   existing_api_endpoint        = var.api_endpoint
   existing_vpc_id              = var.vpc_id
   existing_intra_subnets       = var.intra_subnets
@@ -38,6 +39,7 @@ module "db" {
   instance_class      = var.db_instance_class
   multi_az            = var.db_multi_az
   deletion_protection = var.db_deletion_protection
+  tags               = local.stack_dependent_tags
 }
 
 module "search" {
@@ -59,6 +61,7 @@ module "search" {
   volume_type              = var.search_volume_type
   volume_iops              = var.search_volume_iops
   volume_throughput        = var.search_volume_throughput
+  tags                     = local.stack_dependent_tags
 }
 
 resource "random_password" "admin_password" {

--- a/modules/quilt/outputs.tf
+++ b/modules/quilt/outputs.tf
@@ -19,3 +19,18 @@ output "stack" {
   description = "CloudFormation outputs"
   value       = aws_cloudformation_stack.stack
 }
+
+output "common_tags" {
+  description = "Common tags applied to resources"
+  value       = local.common_tags
+}
+
+output "stack_dependent_tags" {
+  description = "Tags that include the stack ID"
+  value       = local.stack_dependent_tags
+}
+
+output "stack_id" {
+  description = "CloudFormation stack ID"
+  value       = aws_cloudformation_stack.stack.id
+}

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -59,7 +59,7 @@ variable "db_network_type" {
 variable "db_deletion_protection" {
   type        = bool
   nullable    = false
-  default     = true
+  default     = false
   description = "Set to true for production environments to prevent accidental deletion of stack database."
 }
 

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -1,6 +1,3 @@
-locals {
-  stack_dependent_tags = {}
-}
 
 module "search_accessor_security_group" {
   source = "terraform-aws-modules/security-group/aws"
@@ -9,7 +6,7 @@ module "search_accessor_security_group" {
   description = "For resources that need access to search cluster"
   vpc_id      = var.vpc_id
 
-  tags = local.stack_dependent_tags
+  tags = var.tags
 
   egress_with_source_security_group_id = [
     {
@@ -26,7 +23,7 @@ module "search_security_group" {
   description = "For search cluster resources"
   vpc_id      = var.vpc_id
 
-  tags = local.stack_dependent_tags
+  tags = var.tags
 
   ingress_with_source_security_group_id = [
     {
@@ -40,7 +37,7 @@ resource "aws_elasticsearch_domain" "search" {
   domain_name           = var.domain_name
   elasticsearch_version = "6.8"
 
-  tags = local.stack_dependent_tags
+  tags = var.tags
 
   cluster_config {
     instance_count           = var.instance_count

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -1,3 +1,7 @@
+locals {
+  stack_dependent_tags = {}
+}
+
 module "search_accessor_security_group" {
   source = "terraform-aws-modules/security-group/aws"
 

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -5,6 +5,8 @@ module "search_accessor_security_group" {
   description = "For resources that need access to search cluster"
   vpc_id      = var.vpc_id
 
+  tags = local.stack_dependent_tags
+
   egress_with_source_security_group_id = [
     {
       rule                     = "https-443-tcp"
@@ -20,6 +22,8 @@ module "search_security_group" {
   description = "For search cluster resources"
   vpc_id      = var.vpc_id
 
+  tags = local.stack_dependent_tags
+
   ingress_with_source_security_group_id = [
     {
       rule                     = "https-443-tcp"
@@ -31,6 +35,8 @@ module "search_security_group" {
 resource "aws_elasticsearch_domain" "search" {
   domain_name           = var.domain_name
   elasticsearch_version = "6.8"
+
+  tags = local.stack_dependent_tags
 
   cluster_config {
     instance_count           = var.instance_count

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -6,7 +6,6 @@ module "search_accessor_security_group" {
   description = "For resources that need access to search cluster"
   vpc_id      = var.vpc_id
 
-  tags = var.tags
 
   egress_with_source_security_group_id = [
     {

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -71,3 +71,9 @@ variable "volume_type" {
   type     = string
   nullable = false
 }
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -45,6 +45,11 @@ module "vpc" {
   cidr = var.cidr
 
   azs = local.azs
+  
+  # Enable force destroy for testing
+  manage_default_security_group = true
+  default_security_group_ingress = []
+  default_security_group_egress = []
   # 1/2 of address space for each AZ
   # within AZ:
   # 1/2 for private

--- a/tests/.terraform.lock.hcl
+++ b/tests/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.95.0"
+  constraints = ">= 3.29.0, >= 4.65.0, ~> 5.0, >= 5.79.0, >= 5.83.0"
+  hashes = [
+    "h1:PUug/LLWa4GM08rXqnmCVUXj8ibCTvQxgvawhat3bMo=",
+    "zh:20aac8c95edd444e659f235d19fa6af9b259c5a70fce19d400539ee88687e7d4",
+    "zh:29c55846fadd19dde0c5108f74d507c296d6c37cabdd466a96d3721a7c261743",
+    "zh:325fa5cb42d58c9203c279450863c49e534672f7101c067af465f9d7f4be3be5",
+    "zh:4f18c643584f7ba554399c0db3dd1c81629dfc2508a8777890f9f3b80b5213b7",
+    "zh:561e38e9cc6f0be5470c187ea8d51047c4133d9cb74cc1c364a9ebe41f40a06b",
+    "zh:6ec2cceed96ca5e47591ef11686614c663b05e112a814d24246a2739066577b6",
+    "zh:710a227c02b8a50f75a82a7f063d2416e85783e02ed91bb22cc12e7a8e11a3cf",
+    "zh:97a2f5e9bf4cf9a38274eddb7967e1cb4e5b04960c7da3603d9b1c15e18b8626",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf6bfb01fff8226d86c1b219d67cd96f37bb9312b17d00340e6ff00dda2dbe82",
+    "zh:cba74d606149cbaaa8dfb69f369f2496b851643a879adc24b11515fcece42b66",
+    "zh:d5a2c36739cab677a48f4856958c96be6f018ff0da50d233ca93a3a21aaceca1",
+    "zh:df5d1466144852fe5da4af0628db6f02b5186c59f683e5085705d9b90cacfbc0",
+    "zh:f82d96b45983b3c73b78dced9e344512b7a9adb06e8c1e3e4f422605efbb756d",
+    "zh:fb523f787077270059a8f3ab52c0fc56257c0b3a06f0219be247c8b15ff0ca2a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/tests/.terraform.tfstate.lock.info
+++ b/tests/.terraform.tfstate.lock.info
@@ -1,0 +1,1 @@
+{"ID":"a0f7f232-890c-0c76-a0a2-ad318572a35a","Operation":"OperationTypeApply","Info":"","Who":"ernest@Air-Prabhakar.local","Version":"1.5.7","Created":"2025-04-23T00:25:46.93959Z","Path":"terraform.tfstate"}

--- a/tests/.terraform.tfstate.lock.info
+++ b/tests/.terraform.tfstate.lock.info
@@ -1,1 +1,0 @@
-{"ID":"a0f7f232-890c-0c76-a0a2-ad318572a35a","Operation":"OperationTypeApply","Info":"","Who":"ernest@Air-Prabhakar.local","Version":"1.5.7","Created":"2025-04-23T00:25:46.93959Z","Path":"terraform.tfstate"}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,42 @@
+# Quilt Stack Tag Tests
+
+These tests verify that the Quilt module correctly sets tags on AWS resources.
+
+## Prerequisites
+
+1. AWS credentials configured with appropriate permissions
+2. Terraform >= 1.5.0 installed
+3. AWS provider ~> 5.0
+
+## Running the Tests
+
+From any directory:
+
+```bash
+cd tests && terraform init
+cd tests && terraform apply
+```
+
+The test will:
+1. Create a test stack with minimal configuration
+2. Verify the common_tags contain just the stack name
+3. Verify the stack_dependent_tags contain both stack name and stack ID
+4. Output test results as boolean values
+
+### Test Outputs
+
+- `test_common_tags`: Will be `true` if common_tags are correct
+- `test_stack_dependent_tags`: Will be `true` if stack_dependent_tags are correct
+
+### Cleanup
+
+After testing:
+
+```bash
+cd tests && terraform destroy
+```
+
+## Test Files
+
+- `test_tags.tf`: Main test configuration
+- `test.yml`: Minimal CloudFormation template for testing

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,32 +8,63 @@ These tests verify that the Quilt module correctly sets tags on AWS resources.
 2. Terraform >= 1.5.0 installed
 3. AWS provider ~> 5.0
 
+## Finding the Test Stack
+
+When running with `terraform apply`, the test stack will be created in your AWS account with:
+- CloudFormation stack name: "test-stack"
+- All resources will be tagged with "quilt:stack-name = test-stack"
+
+You can find the stack:
+1. In the AWS CloudFormation console under the stack name "test-stack"
+2. By searching for resources with the tag "quilt:stack-name = test-stack"
+3. Using AWS CLI: `aws cloudformation describe-stacks --stack-name test-stack`
+
 ## Running the Tests
 
 From any directory:
 
+```bash
+# First initialize the test environment
 terraform -chdir=tests init
-terraform -chdir=tests apply
+
+# Then plan to verify the configuration
+terraform -chdir=tests plan
+
+# Finally check the test outputs
+terraform -chdir=tests output
 ```
 
 The test will:
-1. Create a test stack with minimal configuration
-2. Verify the common_tags contain just the stack name
-3. Verify the stack_dependent_tags contain both stack name and stack ID
-4. Output test results as boolean values
+1. Show the planned creation of a test stack with minimal configuration
+2. Display the planned common_tags containing just the stack name
+3. Display the planned stack_dependent_tags containing both stack name and stack ID
+4. Show the planned test result outputs as boolean values
 
 ### Test Outputs
 
-- `test_common_tags`: Will be `true` if common_tags are correct
-- `test_stack_dependent_tags`: Will be `true` if stack_dependent_tags are correct
+The test is successful if both outputs are `true`:
+
+```
+test_common_tags = true
+test_stack_dependent_tags = true
+```
+
+You can check the outputs with:
+```bash
+terraform -chdir=tests output
+```
+
+If any output is `false`, the test has failed, indicating the tags are not set correctly.
 
 ### Cleanup
 
-After testing:
+If you ran apply, clean up with:
 
 ```bash
 cd tests && terraform destroy
 ```
+
+Note: No cleanup needed if you only ran plan!
 
 ## Test Files
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,9 +12,8 @@ These tests verify that the Quilt module correctly sets tags on AWS resources.
 
 From any directory:
 
-```bash
-cd tests && terraform init
-cd tests && terraform apply
+terraform -chdir=tests init
+terraform -chdir=tests apply
 ```
 
 The test will:

--- a/tests/terraform.tfstate
+++ b/tests/terraform.tfstate
@@ -1,9 +1,14 @@
 {
   "version": 4,
   "terraform_version": "1.5.7",
-  "serial": 101,
+  "serial": 107,
   "lineage": "75bcca89-5908-83ac-242d-e07d23acebcc",
-  "outputs": {},
+  "outputs": {
+    "test_common_tags": {
+      "value": true,
+      "type": "bool"
+    }
+  },
   "resources": [
     {
       "module": "module.test_stack.module.db.module.db",
@@ -123,7 +128,7 @@
             "db_subnet_group_name": "test-stack-2025042300264134470000000c",
             "dedicated_log_volume": false,
             "delete_automated_backups": true,
-            "deletion_protection": true,
+            "deletion_protection": false,
             "domain": "",
             "domain_auth_secret_arn": "",
             "domain_dns_ips": [],
@@ -145,7 +150,7 @@
             "instance_class": "db.t3.small",
             "iops": 0,
             "kms_key_id": "arn:aws:kms:us-west-2:712023778557:key/e0b18d55-3f79-45ea-8081-7f363c0d0728",
-            "latest_restorable_time": "2025-04-23T01:04:31Z",
+            "latest_restorable_time": "2025-04-23T02:44:35Z",
             "license_model": "postgresql-license",
             "listener_endpoint": [],
             "maintenance_window": "fri:12:06-fri:12:36",
@@ -346,7 +351,21 @@
             "description": "For DB resources",
             "egress": [],
             "id": "sg-020314c863db902e1",
-            "ingress": [],
+            "ingress": [
+              {
+                "cidr_blocks": [],
+                "description": "Ingress Rule",
+                "from_port": 5432,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [
+                  "sg-00e79652941b1f470"
+                ],
+                "self": false,
+                "to_port": 5432
+              }
+            ],
             "name": "test-stack-db-2025042300262363030000000b",
             "name_prefix": "test-stack-db-",
             "owner_id": "712023778557",
@@ -387,47 +406,6 @@
       "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.search.module.search_security_group",
-      "mode": "managed",
-      "type": "aws_security_group",
-      "name": "this_name_prefix",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0a4171800b5592e57",
-            "description": "For search cluster resources",
-            "egress": [],
-            "id": "sg-0a4171800b5592e57",
-            "ingress": [],
-            "name": "test-stack-search-20250423002621879500000009",
-            "name_prefix": "test-stack-search-",
-            "owner_id": "712023778557",
-            "revoke_rules_on_delete": false,
-            "tags": {
-              "Name": "test-stack-search"
-            },
-            "tags_all": {
-              "Name": "test-stack-search"
-            },
-            "timeouts": {
-              "create": "10m",
-              "delete": "15m"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ],
-          "create_before_destroy": true
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.vpc",

--- a/tests/terraform.tfstate
+++ b/tests/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.5.7",
-  "serial": 96,
+  "serial": 101,
   "lineage": "75bcca89-5908-83ac-242d-e07d23acebcc",
   "outputs": {},
   "resources": [
@@ -346,21 +346,7 @@
             "description": "For DB resources",
             "egress": [],
             "id": "sg-020314c863db902e1",
-            "ingress": [
-              {
-                "cidr_blocks": [],
-                "description": "Ingress Rule",
-                "from_port": 5432,
-                "ipv6_cidr_blocks": [],
-                "prefix_list_ids": [],
-                "protocol": "tcp",
-                "security_groups": [
-                  "sg-0d87f94feb586d008"
-                ],
-                "self": false,
-                "to_port": 5432
-              }
-            ],
+            "ingress": [],
             "name": "test-stack-db-2025042300262363030000000b",
             "name_prefix": "test-stack-db-",
             "owner_id": "712023778557",
@@ -383,132 +369,6 @@
             "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
           ],
           "create_before_destroy": true
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.search",
-      "mode": "managed",
-      "type": "aws_elasticsearch_domain",
-      "name": "search",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "access_policies": null,
-            "advanced_options": {},
-            "advanced_security_options": [
-              {
-                "enabled": false,
-                "internal_user_database_enabled": false,
-                "master_user_options": []
-              }
-            ],
-            "arn": "arn:aws:es:us-west-2:712023778557:domain/test-stack",
-            "auto_tune_options": [
-              {
-                "desired_state": "DISABLED",
-                "maintenance_schedule": [],
-                "rollback_on_disable": "NO_ROLLBACK"
-              }
-            ],
-            "cluster_config": [
-              {
-                "cold_storage_options": [
-                  {
-                    "enabled": false
-                  }
-                ],
-                "dedicated_master_count": 0,
-                "dedicated_master_enabled": false,
-                "dedicated_master_type": "",
-                "instance_count": 1,
-                "instance_type": "t3.small.elasticsearch",
-                "warm_count": 0,
-                "warm_enabled": false,
-                "warm_type": "",
-                "zone_awareness_config": [],
-                "zone_awareness_enabled": false
-              }
-            ],
-            "cognito_options": [
-              {
-                "enabled": false,
-                "identity_pool_id": "",
-                "role_arn": "",
-                "user_pool_id": ""
-              }
-            ],
-            "domain_endpoint_options": [
-              {
-                "custom_endpoint": "",
-                "custom_endpoint_certificate_arn": "",
-                "custom_endpoint_enabled": false,
-                "enforce_https": true,
-                "tls_security_policy": "Policy-Min-TLS-1-2-PFS-2023-10"
-              }
-            ],
-            "domain_id": "712023778557/test-stack",
-            "domain_name": "test-stack",
-            "ebs_options": [
-              {
-                "ebs_enabled": true,
-                "iops": 0,
-                "throughput": 0,
-                "volume_size": 10,
-                "volume_type": "gp2"
-              }
-            ],
-            "elasticsearch_version": "6.8",
-            "encrypt_at_rest": [
-              {
-                "enabled": true,
-                "kms_key_id": "arn:aws:kms:us-west-2:712023778557:key/3dffd5ce-c242-408c-b128-27773dd6e618"
-              }
-            ],
-            "endpoint": "vpc-test-stack-jbkakm7setbym6qplyhc3aop44.us-west-2.es.amazonaws.com",
-            "id": "arn:aws:es:us-west-2:712023778557:domain/test-stack",
-            "kibana_endpoint": "vpc-test-stack-jbkakm7setbym6qplyhc3aop44.us-west-2.es.amazonaws.com/_plugin/kibana/",
-            "log_publishing_options": [],
-            "node_to_node_encryption": [
-              {
-                "enabled": true
-              }
-            ],
-            "snapshot_options": [
-              {
-                "automated_snapshot_start_hour": 0
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "timeouts": null,
-            "vpc_options": [
-              {
-                "availability_zones": [
-                  "us-west-2a"
-                ],
-                "security_group_ids": [
-                  "sg-0a4171800b5592e57"
-                ],
-                "subnet_ids": [
-                  "subnet-0b2f3f527ac76bc61"
-                ],
-                "vpc_id": "vpc-08a6cfe215aa111d2"
-              }
-            ]
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAwLCJkZWxldGUiOjU0MDAwMDAwMDAwMDAsInVwZGF0ZSI6MzYwMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.search.module.search_security_group.aws_security_group.this",
-            "module.test_stack.module.search.module.search_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
         }
       ]
     },
@@ -543,21 +403,7 @@
             "description": "For search cluster resources",
             "egress": [],
             "id": "sg-0a4171800b5592e57",
-            "ingress": [
-              {
-                "cidr_blocks": [],
-                "description": "Ingress Rule",
-                "from_port": 443,
-                "ipv6_cidr_blocks": [],
-                "prefix_list_ids": [],
-                "protocol": "tcp",
-                "security_groups": [
-                  "sg-057b092de0195c491"
-                ],
-                "self": false,
-                "to_port": 443
-              }
-            ],
+            "ingress": [],
             "name": "test-stack-search-20250423002621879500000009",
             "name_prefix": "test-stack-search-",
             "owner_id": "712023778557",

--- a/tests/terraform.tfstate
+++ b/tests/terraform.tfstate
@@ -1,212 +1,10 @@
 {
   "version": 4,
   "terraform_version": "1.5.7",
-  "serial": 47,
+  "serial": 96,
   "lineage": "75bcca89-5908-83ac-242d-e07d23acebcc",
-  "outputs": {
-    "test_common_tags": {
-      "value": true,
-      "type": "bool"
-    }
-  },
+  "outputs": {},
   "resources": [
-    {
-      "module": "module.test_stack",
-      "mode": "managed",
-      "type": "aws_cloudformation_stack",
-      "name": "stack",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": []
-    },
-    {
-      "module": "module.test_stack",
-      "mode": "managed",
-      "type": "aws_s3_bucket",
-      "name": "cft_bucket",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "acceleration_status": "",
-            "acl": null,
-            "arn": "arn:aws:s3:::quilt-templates-test-stack-20250423002555455000000001",
-            "bucket": "quilt-templates-test-stack-20250423002555455000000001",
-            "bucket_domain_name": "quilt-templates-test-stack-20250423002555455000000001.s3.amazonaws.com",
-            "bucket_prefix": "quilt-templates-test-stack-",
-            "bucket_regional_domain_name": "quilt-templates-test-stack-20250423002555455000000001.s3.us-west-2.amazonaws.com",
-            "cors_rule": [],
-            "force_destroy": true,
-            "grant": [
-              {
-                "id": "b035c754b9182851f427b323faff3cde0f4a6f6ce0bc0ea7fde56948b8386a20",
-                "permissions": [
-                  "FULL_CONTROL"
-                ],
-                "type": "CanonicalUser",
-                "uri": ""
-              }
-            ],
-            "hosted_zone_id": "Z3BJ6K6RIION7M",
-            "id": "quilt-templates-test-stack-20250423002555455000000001",
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "object_lock_enabled": false,
-            "policy": "",
-            "region": "us-west-2",
-            "replication_configuration": [],
-            "request_payer": "BucketOwner",
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {
-                        "kms_master_key_id": "",
-                        "sse_algorithm": "AES256"
-                      }
-                    ],
-                    "bucket_key_enabled": false
-                  }
-                ]
-              }
-            ],
-            "tags": {
-              "quilt:stack-name": "test-stack"
-            },
-            "tags_all": {
-              "quilt:stack-name": "test-stack"
-            },
-            "timeouts": null,
-            "versioning": [
-              {
-                "enabled": false,
-                "mfa_delete": false
-              }
-            ],
-            "website": [],
-            "website_domain": null,
-            "website_endpoint": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack",
-      "mode": "managed",
-      "type": "aws_s3_bucket_versioning",
-      "name": "cft_bucket_versioning",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "bucket": "quilt-templates-test-stack-20250423002555455000000001",
-            "expected_bucket_owner": "",
-            "id": "quilt-templates-test-stack-20250423002555455000000001",
-            "mfa": null,
-            "versioning_configuration": [
-              {
-                "mfa_delete": "",
-                "status": "Enabled"
-              }
-            ]
-          },
-          "sensitive_attributes": [],
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.test_stack.aws_s3_bucket.cft_bucket"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack",
-      "mode": "managed",
-      "type": "aws_s3_object",
-      "name": "cft",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "acl": null,
-            "arn": "arn:aws:s3:::quilt-templates-test-stack-20250423002555455000000001/quilt.yaml",
-            "bucket": "quilt-templates-test-stack-20250423002555455000000001",
-            "bucket_key_enabled": false,
-            "cache_control": "",
-            "checksum_algorithm": null,
-            "checksum_crc32": "",
-            "checksum_crc32c": "",
-            "checksum_crc64nvme": "",
-            "checksum_sha1": "",
-            "checksum_sha256": "",
-            "content": null,
-            "content_base64": null,
-            "content_disposition": "",
-            "content_encoding": "",
-            "content_language": "",
-            "content_type": "application/octet-stream",
-            "etag": "7a684fe1081285d879cc3349d1cf6f5f",
-            "force_destroy": false,
-            "id": "quilt.yaml",
-            "key": "quilt.yaml",
-            "kms_key_id": null,
-            "metadata": null,
-            "object_lock_legal_hold_status": "",
-            "object_lock_mode": "",
-            "object_lock_retain_until_date": "",
-            "override_provider": [],
-            "server_side_encryption": "AES256",
-            "source": "./test.yml",
-            "source_hash": null,
-            "storage_class": "STANDARD",
-            "tags": null,
-            "tags_all": {},
-            "version_id": "8oDqK42lzSykoZR8.frzrhqlY6Ho92m6",
-            "website_redirect": ""
-          },
-          "sensitive_attributes": [],
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.test_stack.aws_s3_bucket.cft_bucket"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack",
-      "mode": "managed",
-      "type": "random_password",
-      "name": "admin_password",
-      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
-      "instances": [
-        {
-          "schema_version": 3,
-          "attributes": {
-            "bcrypt_hash": "$2a$10$Ak8ixWvbquGVqNBpyYD3tedQxC/t0qKsX9SGqZnozozTFENj0dMY.",
-            "id": "none",
-            "keepers": null,
-            "length": 16,
-            "lower": true,
-            "min_lower": 0,
-            "min_numeric": 0,
-            "min_special": 0,
-            "min_upper": 0,
-            "number": true,
-            "numeric": true,
-            "override_special": null,
-            "result": "GAVBFgD\u003ezV:$C_7J",
-            "special": true,
-            "upper": true
-          },
-          "sensitive_attributes": []
-        }
-      ]
-    },
     {
       "module": "module.test_stack.module.db.module.db",
       "mode": "managed",
@@ -286,25 +84,6 @@
     },
     {
       "module": "module.test_stack.module.db.module.db.module.db_instance",
-      "mode": "data",
-      "type": "aws_partition",
-      "name": "current",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "dns_suffix": "amazonaws.com",
-            "id": "aws",
-            "partition": "aws",
-            "reverse_dns_prefix": "com.amazonaws"
-          },
-          "sensitive_attributes": []
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.db.module.db.module.db_instance",
       "mode": "managed",
       "type": "aws_cloudwatch_log_group",
       "name": "this",
@@ -317,7 +96,131 @@
       "type": "aws_db_instance",
       "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": []
+      "instances": [
+        {
+          "index_key": 0,
+          "status": "tainted",
+          "schema_version": 2,
+          "attributes": {
+            "address": "test-stack.cz5fnzdopp73.us-west-2.rds.amazonaws.com",
+            "allocated_storage": 100,
+            "allow_major_version_upgrade": true,
+            "apply_immediately": true,
+            "arn": "arn:aws:rds:us-west-2:712023778557:db:test-stack",
+            "auto_minor_version_upgrade": false,
+            "availability_zone": "us-west-2a",
+            "backup_retention_period": 7,
+            "backup_target": "region",
+            "backup_window": "08:06-08:36",
+            "blue_green_update": [],
+            "ca_cert_identifier": "rds-ca-rsa2048-g1",
+            "character_set_name": "",
+            "copy_tags_to_snapshot": false,
+            "custom_iam_instance_profile": "",
+            "customer_owned_ip_enabled": false,
+            "database_insights_mode": "standard",
+            "db_name": "quilt",
+            "db_subnet_group_name": "test-stack-2025042300264134470000000c",
+            "dedicated_log_volume": false,
+            "delete_automated_backups": true,
+            "deletion_protection": true,
+            "domain": "",
+            "domain_auth_secret_arn": "",
+            "domain_dns_ips": [],
+            "domain_fqdn": "",
+            "domain_iam_role_name": "",
+            "domain_ou": "",
+            "enabled_cloudwatch_logs_exports": [],
+            "endpoint": "test-stack.cz5fnzdopp73.us-west-2.rds.amazonaws.com:5432",
+            "engine": "postgres",
+            "engine_lifecycle_support": "open-source-rds-extended-support",
+            "engine_version": "15.12",
+            "engine_version_actual": "15.12",
+            "final_snapshot_identifier": "final-test-stack-26a37146",
+            "hosted_zone_id": "Z1PVIF0B656C1W",
+            "iam_database_authentication_enabled": false,
+            "id": "db-HZQXH5YHJUDJWVIED2A26PDVYU",
+            "identifier": "test-stack",
+            "identifier_prefix": "",
+            "instance_class": "db.t3.small",
+            "iops": 0,
+            "kms_key_id": "arn:aws:kms:us-west-2:712023778557:key/e0b18d55-3f79-45ea-8081-7f363c0d0728",
+            "latest_restorable_time": "2025-04-23T01:04:31Z",
+            "license_model": "postgresql-license",
+            "listener_endpoint": [],
+            "maintenance_window": "fri:12:06-fri:12:36",
+            "manage_master_user_password": null,
+            "master_user_secret": [],
+            "master_user_secret_kms_key_id": null,
+            "max_allocated_storage": 0,
+            "monitoring_interval": 0,
+            "monitoring_role_arn": "",
+            "multi_az": true,
+            "nchar_character_set_name": "",
+            "network_type": "DUAL",
+            "option_group_name": "default:postgres-15",
+            "parameter_group_name": "default.postgres15",
+            "password": "vADu1f7Yql0OEHoI",
+            "password_wo": null,
+            "password_wo_version": null,
+            "performance_insights_enabled": false,
+            "performance_insights_kms_key_id": "",
+            "performance_insights_retention_period": 0,
+            "port": 5432,
+            "publicly_accessible": false,
+            "replica_mode": "",
+            "replicas": [],
+            "replicate_source_db": "",
+            "resource_id": "db-HZQXH5YHJUDJWVIED2A26PDVYU",
+            "restore_to_point_in_time": [],
+            "s3_import": [],
+            "skip_final_snapshot": false,
+            "snapshot_identifier": null,
+            "status": "available",
+            "storage_encrypted": true,
+            "storage_throughput": 0,
+            "storage_type": "gp2",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": {
+              "create": null,
+              "delete": null,
+              "update": null
+            },
+            "timezone": "",
+            "upgrade_storage_config": null,
+            "username": "root",
+            "vpc_security_group_ids": [
+              "sg-020314c863db902e1"
+            ]
+          },
+          "sensitive_attributes": [
+            [
+              {
+                "type": "get_attr",
+                "value": "password"
+              }
+            ]
+          ],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInVwZGF0ZSI6NDgwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMiJ9",
+          "dependencies": [
+            "module.test_stack.module.db.module.db.module.db_instance.aws_cloudwatch_log_group.this",
+            "module.test_stack.module.db.module.db.module.db_instance.aws_iam_role.enhanced_monitoring",
+            "module.test_stack.module.db.module.db.module.db_instance.data.aws_iam_policy_document.enhanced_monitoring",
+            "module.test_stack.module.db.module.db.module.db_instance.random_id.snapshot_identifier",
+            "module.test_stack.module.db.module.db.module.db_option_group.aws_db_option_group.this",
+            "module.test_stack.module.db.module.db.module.db_parameter_group.aws_db_parameter_group.this",
+            "module.test_stack.module.db.module.db.module.db_subnet_group.aws_db_subnet_group.this",
+            "module.test_stack.module.db.module.db.random_password.master_password",
+            "module.test_stack.module.db.module.db_security_group.aws_security_group.this",
+            "module.test_stack.module.db.module.db_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
     },
     {
       "module": "module.test_stack.module.db.module.db.module.db_instance",
@@ -421,85 +324,6 @@
       "instances": []
     },
     {
-      "module": "module.test_stack.module.db.module.db_accessor_security_group",
-      "mode": "managed",
-      "type": "aws_security_group",
-      "name": "this_name_prefix",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0d87f94feb586d008",
-            "description": "For resources that need access to DB",
-            "egress": [],
-            "id": "sg-0d87f94feb586d008",
-            "ingress": [],
-            "name": "test-stack-db-accessor-2025042300262208060000000a",
-            "name_prefix": "test-stack-db-accessor-",
-            "owner_id": "712023778557",
-            "revoke_rules_on_delete": false,
-            "tags": {
-              "Name": "test-stack-db-accessor"
-            },
-            "tags_all": {
-              "Name": "test-stack-db-accessor"
-            },
-            "timeouts": {
-              "create": "10m",
-              "delete": "15m"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ],
-          "create_before_destroy": true
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.db.module.db_accessor_security_group",
-      "mode": "managed",
-      "type": "aws_security_group_rule",
-      "name": "egress_with_source_security_group_id",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 2,
-          "attributes": {
-            "cidr_blocks": null,
-            "description": "Egress Rule",
-            "from_port": 5432,
-            "id": "sgrule-3619442631",
-            "ipv6_cidr_blocks": null,
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_group_id": "sg-0d87f94feb586d008",
-            "security_group_rule_id": "sgr-0b5c4119aa3ccefa3",
-            "self": false,
-            "source_security_group_id": "sg-020314c863db902e1",
-            "timeouts": null,
-            "to_port": 5432,
-            "type": "egress"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
-          "dependencies": [
-            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this",
-            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.db.module.db_security_group.aws_security_group.this",
-            "module.test_stack.module.db.module.db_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
-    },
-    {
       "module": "module.test_stack.module.db.module.db_security_group",
       "mode": "managed",
       "type": "aws_security_group",
@@ -522,7 +346,21 @@
             "description": "For DB resources",
             "egress": [],
             "id": "sg-020314c863db902e1",
-            "ingress": [],
+            "ingress": [
+              {
+                "cidr_blocks": [],
+                "description": "Ingress Rule",
+                "from_port": 5432,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [
+                  "sg-0d87f94feb586d008"
+                ],
+                "self": false,
+                "to_port": 5432
+              }
+            ],
             "name": "test-stack-db-2025042300262363030000000b",
             "name_prefix": "test-stack-db-",
             "owner_id": "712023778557",
@@ -549,50 +387,130 @@
       ]
     },
     {
-      "module": "module.test_stack.module.db.module.db_security_group",
-      "mode": "managed",
-      "type": "aws_security_group_rule",
-      "name": "ingress_with_source_security_group_id",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 2,
-          "attributes": {
-            "cidr_blocks": null,
-            "description": "Ingress Rule",
-            "from_port": 5432,
-            "id": "sgrule-1154694529",
-            "ipv6_cidr_blocks": null,
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_group_id": "sg-020314c863db902e1",
-            "security_group_rule_id": "sgr-02144ce34846605a9",
-            "self": false,
-            "source_security_group_id": "sg-0d87f94feb586d008",
-            "timeouts": null,
-            "to_port": 5432,
-            "type": "ingress"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
-          "dependencies": [
-            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this",
-            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.db.module.db_security_group.aws_security_group.this",
-            "module.test_stack.module.db.module.db_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
-    },
-    {
       "module": "module.test_stack.module.search",
       "mode": "managed",
       "type": "aws_elasticsearch_domain",
       "name": "search",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": []
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_policies": null,
+            "advanced_options": {},
+            "advanced_security_options": [
+              {
+                "enabled": false,
+                "internal_user_database_enabled": false,
+                "master_user_options": []
+              }
+            ],
+            "arn": "arn:aws:es:us-west-2:712023778557:domain/test-stack",
+            "auto_tune_options": [
+              {
+                "desired_state": "DISABLED",
+                "maintenance_schedule": [],
+                "rollback_on_disable": "NO_ROLLBACK"
+              }
+            ],
+            "cluster_config": [
+              {
+                "cold_storage_options": [
+                  {
+                    "enabled": false
+                  }
+                ],
+                "dedicated_master_count": 0,
+                "dedicated_master_enabled": false,
+                "dedicated_master_type": "",
+                "instance_count": 1,
+                "instance_type": "t3.small.elasticsearch",
+                "warm_count": 0,
+                "warm_enabled": false,
+                "warm_type": "",
+                "zone_awareness_config": [],
+                "zone_awareness_enabled": false
+              }
+            ],
+            "cognito_options": [
+              {
+                "enabled": false,
+                "identity_pool_id": "",
+                "role_arn": "",
+                "user_pool_id": ""
+              }
+            ],
+            "domain_endpoint_options": [
+              {
+                "custom_endpoint": "",
+                "custom_endpoint_certificate_arn": "",
+                "custom_endpoint_enabled": false,
+                "enforce_https": true,
+                "tls_security_policy": "Policy-Min-TLS-1-2-PFS-2023-10"
+              }
+            ],
+            "domain_id": "712023778557/test-stack",
+            "domain_name": "test-stack",
+            "ebs_options": [
+              {
+                "ebs_enabled": true,
+                "iops": 0,
+                "throughput": 0,
+                "volume_size": 10,
+                "volume_type": "gp2"
+              }
+            ],
+            "elasticsearch_version": "6.8",
+            "encrypt_at_rest": [
+              {
+                "enabled": true,
+                "kms_key_id": "arn:aws:kms:us-west-2:712023778557:key/3dffd5ce-c242-408c-b128-27773dd6e618"
+              }
+            ],
+            "endpoint": "vpc-test-stack-jbkakm7setbym6qplyhc3aop44.us-west-2.es.amazonaws.com",
+            "id": "arn:aws:es:us-west-2:712023778557:domain/test-stack",
+            "kibana_endpoint": "vpc-test-stack-jbkakm7setbym6qplyhc3aop44.us-west-2.es.amazonaws.com/_plugin/kibana/",
+            "log_publishing_options": [],
+            "node_to_node_encryption": [
+              {
+                "enabled": true
+              }
+            ],
+            "snapshot_options": [
+              {
+                "automated_snapshot_start_hour": 0
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_options": [
+              {
+                "availability_zones": [
+                  "us-west-2a"
+                ],
+                "security_group_ids": [
+                  "sg-0a4171800b5592e57"
+                ],
+                "subnet_ids": [
+                  "subnet-0b2f3f527ac76bc61"
+                ],
+                "vpc_id": "vpc-08a6cfe215aa111d2"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAwLCJkZWxldGUiOjU0MDAwMDAwMDAwMDAsInVwZGF0ZSI6MzYwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.search.module.search_security_group.aws_security_group.this",
+            "module.test_stack.module.search.module.search_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
     },
     {
       "module": "module.test_stack.module.search.module.search_accessor_security_group",
@@ -601,85 +519,6 @@
       "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.search.module.search_accessor_security_group",
-      "mode": "managed",
-      "type": "aws_security_group",
-      "name": "this_name_prefix",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-057b092de0195c491",
-            "description": "For resources that need access to search cluster",
-            "egress": [],
-            "id": "sg-057b092de0195c491",
-            "ingress": [],
-            "name": "test-stack-search-accessor-20250423002621511800000008",
-            "name_prefix": "test-stack-search-accessor-",
-            "owner_id": "712023778557",
-            "revoke_rules_on_delete": false,
-            "tags": {
-              "Name": "test-stack-search-accessor"
-            },
-            "tags_all": {
-              "Name": "test-stack-search-accessor"
-            },
-            "timeouts": {
-              "create": "10m",
-              "delete": "15m"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ],
-          "create_before_destroy": true
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.search.module.search_accessor_security_group",
-      "mode": "managed",
-      "type": "aws_security_group_rule",
-      "name": "egress_with_source_security_group_id",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 2,
-          "attributes": {
-            "cidr_blocks": null,
-            "description": "Egress Rule",
-            "from_port": 443,
-            "id": "sgrule-1712243089",
-            "ipv6_cidr_blocks": null,
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_group_id": "sg-057b092de0195c491",
-            "security_group_rule_id": "sgr-01dabe1817e4c4658",
-            "self": false,
-            "source_security_group_id": "sg-0a4171800b5592e57",
-            "timeouts": null,
-            "to_port": 443,
-            "type": "egress"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
-          "dependencies": [
-            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this",
-            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.search.module.search_security_group.aws_security_group.this",
-            "module.test_stack.module.search.module.search_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.search.module.search_security_group",
@@ -704,7 +543,21 @@
             "description": "For search cluster resources",
             "egress": [],
             "id": "sg-0a4171800b5592e57",
-            "ingress": [],
+            "ingress": [
+              {
+                "cidr_blocks": [],
+                "description": "Ingress Rule",
+                "from_port": 443,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [
+                  "sg-057b092de0195c491"
+                ],
+                "self": false,
+                "to_port": 443
+              }
+            ],
             "name": "test-stack-search-20250423002621879500000009",
             "name_prefix": "test-stack-search-",
             "owner_id": "712023778557",
@@ -727,44 +580,6 @@
             "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
           ],
           "create_before_destroy": true
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.search.module.search_security_group",
-      "mode": "managed",
-      "type": "aws_security_group_rule",
-      "name": "ingress_with_source_security_group_id",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 2,
-          "attributes": {
-            "cidr_blocks": null,
-            "description": "Ingress Rule",
-            "from_port": 443,
-            "id": "sgrule-2113705527",
-            "ipv6_cidr_blocks": null,
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_group_id": "sg-0a4171800b5592e57",
-            "security_group_rule_id": "sgr-02ffb2290680ae40c",
-            "self": false,
-            "source_security_group_id": "sg-057b092de0195c491",
-            "timeouts": null,
-            "to_port": 443,
-            "type": "ingress"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
-          "dependencies": [
-            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this",
-            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.search.module.search_security_group.aws_security_group.this",
-            "module.test_stack.module.search.module.search_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
         }
       ]
     },
@@ -814,114 +629,6 @@
       "instances": []
     },
     {
-      "module": "module.test_stack.module.vpc.module.api_gateway_security_group",
-      "mode": "managed",
-      "type": "aws_security_group",
-      "name": "this_name_prefix",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0dfa77448bfa8ca1b",
-            "description": "User ingress security group for API Gateway Endpoint, Quilt load balancer",
-            "egress": [],
-            "id": "sg-0dfa77448bfa8ca1b",
-            "ingress": [],
-            "name": "test-stack-user-ingress-20250423002621281500000007",
-            "name_prefix": "test-stack-user-ingress-",
-            "owner_id": "712023778557",
-            "revoke_rules_on_delete": false,
-            "tags": {
-              "Name": "test-stack-user-ingress"
-            },
-            "tags_all": {
-              "Name": "test-stack-user-ingress"
-            },
-            "timeouts": {
-              "create": "10m",
-              "delete": "15m"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ],
-          "create_before_destroy": true
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.api_gateway_security_group",
-      "mode": "managed",
-      "type": "aws_security_group_rule",
-      "name": "ingress_rules",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 2,
-          "attributes": {
-            "cidr_blocks": [
-              "0.0.0.0/0"
-            ],
-            "description": "HTTPS",
-            "from_port": 443,
-            "id": "sgrule-2647011336",
-            "ipv6_cidr_blocks": [],
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_group_id": "sg-0dfa77448bfa8ca1b",
-            "security_group_rule_id": "sgr-003839800c12cd55a",
-            "self": false,
-            "source_security_group_id": null,
-            "timeouts": null,
-            "to_port": 443,
-            "type": "ingress"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this",
-            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 2,
-          "attributes": {
-            "cidr_blocks": [
-              "0.0.0.0/0"
-            ],
-            "description": "HTTP",
-            "from_port": 80,
-            "id": "sgrule-3431647834",
-            "ipv6_cidr_blocks": [],
-            "prefix_list_ids": [],
-            "protocol": "tcp",
-            "security_group_id": "sg-0dfa77448bfa8ca1b",
-            "security_group_rule_id": "sgr-0c48cb5b5745ba17e",
-            "self": false,
-            "source_security_group_id": null,
-            "timeouts": null,
-            "to_port": 80,
-            "type": "ingress"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this",
-            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
-    },
-    {
       "module": "module.test_stack.module.vpc.module.vpc",
       "mode": "managed",
       "type": "aws_cloudwatch_log_group",
@@ -948,250 +655,10 @@
     {
       "module": "module.test_stack.module.vpc.module.vpc",
       "mode": "managed",
-      "type": "aws_default_network_acl",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:network-acl/acl-03e9a45c813025712",
-            "default_network_acl_id": "acl-03e9a45c813025712",
-            "egress": [
-              {
-                "action": "allow",
-                "cidr_block": "",
-                "from_port": 0,
-                "icmp_code": null,
-                "icmp_type": null,
-                "ipv6_cidr_block": "::/0",
-                "protocol": "-1",
-                "rule_no": 101,
-                "to_port": 0
-              },
-              {
-                "action": "allow",
-                "cidr_block": "0.0.0.0/0",
-                "from_port": 0,
-                "icmp_code": null,
-                "icmp_type": null,
-                "ipv6_cidr_block": "",
-                "protocol": "-1",
-                "rule_no": 100,
-                "to_port": 0
-              }
-            ],
-            "id": "acl-03e9a45c813025712",
-            "ingress": [
-              {
-                "action": "allow",
-                "cidr_block": "",
-                "from_port": 0,
-                "icmp_code": null,
-                "icmp_type": null,
-                "ipv6_cidr_block": "::/0",
-                "protocol": "-1",
-                "rule_no": 101,
-                "to_port": 0
-              },
-              {
-                "action": "allow",
-                "cidr_block": "0.0.0.0/0",
-                "from_port": 0,
-                "icmp_code": null,
-                "icmp_type": null,
-                "ipv6_cidr_block": "",
-                "protocol": "-1",
-                "rule_no": 100,
-                "to_port": 0
-              }
-            ],
-            "owner_id": "712023778557",
-            "subnet_ids": [
-              "subnet-01f4f3ae425a408e5",
-              "subnet-06f7cbe14df00ee8c",
-              "subnet-0850b8f168c863fbb",
-              "subnet-0b2f3f527ac76bc61",
-              "subnet-0d9b23c7315330852"
-            ],
-            "tags": {
-              "Name": "test-stack-default"
-            },
-            "tags_all": {
-              "Name": "test-stack-default"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_default_route_table",
-      "name": "default",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-0dca290699431a6a1",
-            "default_route_table_id": "rtb-0dca290699431a6a1",
-            "id": "rtb-0dca290699431a6a1",
-            "owner_id": "712023778557",
-            "propagating_vgws": null,
-            "route": [],
-            "tags": {
-              "Name": "test-stack-default"
-            },
-            "tags_all": {
-              "Name": "test-stack-default"
-            },
-            "timeouts": {
-              "create": "5m",
-              "update": "5m"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_default_security_group",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0c866a5d608a24b01",
-            "description": "default VPC security group",
-            "egress": [],
-            "id": "sg-0c866a5d608a24b01",
-            "ingress": [],
-            "name": "default",
-            "name_prefix": "",
-            "owner_id": "712023778557",
-            "revoke_rules_on_delete": false,
-            "tags": {
-              "Name": "test-stack-default"
-            },
-            "tags_all": {
-              "Name": "test-stack-default"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
-          "dependencies": [
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
       "type": "aws_default_vpc",
       "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_egress_only_internet_gateway",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "id": "eigw-007a5419e6f24aac3",
-            "tags": {
-              "Name": "test-stack"
-            },
-            "tags_all": {
-              "Name": "test-stack"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_eip",
-      "name": "nat",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 1,
-          "schema_version": 0,
-          "attributes": {
-            "address": null,
-            "allocation_id": "eipalloc-04bcf73b1477b83a0",
-            "arn": "arn:aws:ec2:us-west-2:712023778557:elastic-ip/eipalloc-04bcf73b1477b83a0",
-            "associate_with_private_ip": null,
-            "association_id": "",
-            "carrier_ip": "",
-            "customer_owned_ip": "",
-            "customer_owned_ipv4_pool": "",
-            "domain": "vpc",
-            "id": "eipalloc-04bcf73b1477b83a0",
-            "instance": "",
-            "ipam_pool_id": null,
-            "network_border_group": "us-west-2",
-            "network_interface": "",
-            "private_dns": null,
-            "private_ip": "",
-            "ptr_record": "",
-            "public_dns": "ec2-54-190-19-19.us-west-2.compute.amazonaws.com",
-            "public_ip": "54.190.19.19",
-            "public_ipv4_pool": "amazon",
-            "tags": {
-              "Name": "test-stack-us-west-2b"
-            },
-            "tags_all": {
-              "Name": "test-stack-us-west-2b"
-            },
-            "timeouts": null,
-            "vpc": true
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxODAwMDAwMDAwMDAsInJlYWQiOjkwMDAwMDAwMDAwMCwidXBkYXRlIjozMDAwMDAwMDAwMDB9fQ==",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_internet_gateway.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.vpc.module.vpc",
@@ -1214,47 +681,6 @@
       "mode": "managed",
       "type": "aws_iam_role",
       "name": "vpc_flow_log_cloudwatch",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": []
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_internet_gateway",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:internet-gateway/igw-0eb692813ce15f3a7",
-            "id": "igw-0eb692813ce15f3a7",
-            "owner_id": "712023778557",
-            "tags": {
-              "Name": "test-stack"
-            },
-            "tags_all": {
-              "Name": "test-stack"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_nat_gateway",
-      "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
     },
@@ -1349,185 +775,6 @@
     {
       "module": "module.test_stack.module.vpc.module.vpc",
       "mode": "managed",
-      "type": "aws_route",
-      "name": "private_ipv6_egress",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "carrier_gateway_id": "",
-            "core_network_arn": "",
-            "destination_cidr_block": "",
-            "destination_ipv6_cidr_block": "::/0",
-            "destination_prefix_list_id": "",
-            "egress_only_gateway_id": "eigw-007a5419e6f24aac3",
-            "gateway_id": "",
-            "id": "r-rtb-0df3d3d3244e792882750132062",
-            "instance_id": "",
-            "instance_owner_id": "",
-            "local_gateway_id": "",
-            "nat_gateway_id": "",
-            "network_interface_id": "",
-            "origin": "CreateRoute",
-            "route_table_id": "rtb-0df3d3d3244e79288",
-            "state": "active",
-            "timeouts": null,
-            "transit_gateway_id": "",
-            "vpc_endpoint_id": "",
-            "vpc_peering_connection_id": ""
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_egress_only_internet_gateway.this",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 0,
-          "attributes": {
-            "carrier_gateway_id": "",
-            "core_network_arn": "",
-            "destination_cidr_block": "",
-            "destination_ipv6_cidr_block": "::/0",
-            "destination_prefix_list_id": "",
-            "egress_only_gateway_id": "eigw-007a5419e6f24aac3",
-            "gateway_id": "",
-            "id": "r-rtb-05cb3223c3341fe672750132062",
-            "instance_id": "",
-            "instance_owner_id": "",
-            "local_gateway_id": "",
-            "nat_gateway_id": "",
-            "network_interface_id": "",
-            "origin": "CreateRoute",
-            "route_table_id": "rtb-05cb3223c3341fe67",
-            "state": "active",
-            "timeouts": null,
-            "transit_gateway_id": "",
-            "vpc_endpoint_id": "",
-            "vpc_peering_connection_id": ""
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_egress_only_internet_gateway.this",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route",
-      "name": "private_nat_gateway",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": []
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route",
-      "name": "public_internet_gateway",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "carrier_gateway_id": "",
-            "core_network_arn": "",
-            "destination_cidr_block": "0.0.0.0/0",
-            "destination_ipv6_cidr_block": "",
-            "destination_prefix_list_id": "",
-            "egress_only_gateway_id": "",
-            "gateway_id": "igw-0eb692813ce15f3a7",
-            "id": "r-rtb-06fe5396cbb825c571080289494",
-            "instance_id": "",
-            "instance_owner_id": "",
-            "local_gateway_id": "",
-            "nat_gateway_id": "",
-            "network_interface_id": "",
-            "origin": "CreateRoute",
-            "route_table_id": "rtb-06fe5396cbb825c57",
-            "state": "active",
-            "timeouts": {
-              "create": "5m",
-              "delete": null,
-              "update": null
-            },
-            "transit_gateway_id": "",
-            "vpc_endpoint_id": "",
-            "vpc_peering_connection_id": ""
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_internet_gateway.this",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route",
-      "name": "public_internet_gateway_ipv6",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "carrier_gateway_id": "",
-            "core_network_arn": "",
-            "destination_cidr_block": "",
-            "destination_ipv6_cidr_block": "::/0",
-            "destination_prefix_list_id": "",
-            "egress_only_gateway_id": "",
-            "gateway_id": "igw-0eb692813ce15f3a7",
-            "id": "r-rtb-06fe5396cbb825c572750132062",
-            "instance_id": "",
-            "instance_owner_id": "",
-            "local_gateway_id": "",
-            "nat_gateway_id": "",
-            "network_interface_id": "",
-            "origin": "CreateRoute",
-            "route_table_id": "rtb-06fe5396cbb825c57",
-            "state": "active",
-            "timeouts": null,
-            "transit_gateway_id": "",
-            "vpc_endpoint_id": "",
-            "vpc_peering_connection_id": ""
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_internet_gateway.this",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
       "type": "aws_route_table",
       "name": "database",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
@@ -1540,137 +787,6 @@
       "name": "elasticache",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route_table",
-      "name": "intra",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-0905294eb9954fb2c",
-            "id": "rtb-0905294eb9954fb2c",
-            "owner_id": "712023778557",
-            "propagating_vgws": [],
-            "route": [],
-            "tags": {
-              "Name": "test-stack-intra"
-            },
-            "tags_all": {
-              "Name": "test-stack-intra"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route_table",
-      "name": "private",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-0df3d3d3244e79288",
-            "id": "rtb-0df3d3d3244e79288",
-            "owner_id": "712023778557",
-            "propagating_vgws": [],
-            "route": [],
-            "tags": {
-              "Name": "test-stack-private-us-west-2a"
-            },
-            "tags_all": {
-              "Name": "test-stack-private-us-west-2a"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-05cb3223c3341fe67",
-            "id": "rtb-05cb3223c3341fe67",
-            "owner_id": "712023778557",
-            "propagating_vgws": [],
-            "route": [],
-            "tags": {
-              "Name": "test-stack-private-us-west-2b"
-            },
-            "tags_all": {
-              "Name": "test-stack-private-us-west-2b"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route_table",
-      "name": "public",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-06fe5396cbb825c57",
-            "id": "rtb-06fe5396cbb825c57",
-            "owner_id": "712023778557",
-            "propagating_vgws": [],
-            "route": [],
-            "tags": {
-              "Name": "test-stack-public"
-            },
-            "tags_all": {
-              "Name": "test-stack-public"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.vpc.module.vpc",
@@ -1695,153 +811,6 @@
       "name": "elasticache",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route_table_association",
-      "name": "intra",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "gateway_id": "",
-            "id": "rtbassoc-0acc9582ba89420f7",
-            "route_table_id": "rtb-0905294eb9954fb2c",
-            "subnet_id": "subnet-0b2f3f527ac76bc61",
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 0,
-          "attributes": {
-            "gateway_id": "",
-            "id": "rtbassoc-023485c5a70dc3388",
-            "route_table_id": "rtb-0905294eb9954fb2c",
-            "subnet_id": "subnet-06f7cbe14df00ee8c",
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route_table_association",
-      "name": "private",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "gateway_id": "",
-            "id": "rtbassoc-0d1a7d33f547403e0",
-            "route_table_id": "rtb-0df3d3d3244e79288",
-            "subnet_id": "subnet-0850b8f168c863fbb",
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.private",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 0,
-          "attributes": {
-            "gateway_id": "",
-            "id": "rtbassoc-04bae89e981642fea",
-            "route_table_id": "rtb-05cb3223c3341fe67",
-            "subnet_id": "subnet-0d9b23c7315330852",
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.private",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_route_table_association",
-      "name": "public",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "gateway_id": "",
-            "id": "rtbassoc-0b7eb8d1f513b38ad",
-            "route_table_id": "rtb-06fe5396cbb825c57",
-            "subnet_id": "subnet-03e38b08477729e56",
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.public",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 0,
-          "attributes": {
-            "gateway_id": "",
-            "id": "rtbassoc-004aadc43aec3ea10",
-            "route_table_id": "rtb-06fe5396cbb825c57",
-            "subnet_id": "subnet-01f4f3ae425a408e5",
-            "timeouts": null
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.public",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.vpc.module.vpc",
@@ -1976,184 +945,6 @@
       "module": "module.test_stack.module.vpc.module.vpc",
       "mode": "managed",
       "type": "aws_subnet",
-      "name": "private",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-0850b8f168c863fbb",
-            "assign_ipv6_address_on_creation": true,
-            "availability_zone": "us-west-2a",
-            "availability_zone_id": "usw2-az2",
-            "cidr_block": "10.0.0.0/18",
-            "customer_owned_ipv4_pool": "",
-            "enable_dns64": false,
-            "enable_lni_at_device_index": 0,
-            "enable_resource_name_dns_a_record_on_launch": false,
-            "enable_resource_name_dns_aaaa_record_on_launch": true,
-            "id": "subnet-0850b8f168c863fbb",
-            "ipv6_cidr_block": "2600:1f14:34ee:ca02::/64",
-            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-08ad55c85e0a22c75",
-            "ipv6_native": false,
-            "map_customer_owned_ip_on_launch": false,
-            "map_public_ip_on_launch": false,
-            "outpost_arn": "",
-            "owner_id": "712023778557",
-            "private_dns_hostname_type_on_launch": "ip-name",
-            "tags": {
-              "Name": "test-stack-private-us-west-2a"
-            },
-            "tags_all": {
-              "Name": "test-stack-private-us-west-2a"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-0d9b23c7315330852",
-            "assign_ipv6_address_on_creation": true,
-            "availability_zone": "us-west-2b",
-            "availability_zone_id": "usw2-az1",
-            "cidr_block": "10.0.128.0/18",
-            "customer_owned_ipv4_pool": "",
-            "enable_dns64": false,
-            "enable_lni_at_device_index": 0,
-            "enable_resource_name_dns_a_record_on_launch": false,
-            "enable_resource_name_dns_aaaa_record_on_launch": true,
-            "id": "subnet-0d9b23c7315330852",
-            "ipv6_cidr_block": "2600:1f14:34ee:ca03::/64",
-            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-0d561f75bfe0565b1",
-            "ipv6_native": false,
-            "map_customer_owned_ip_on_launch": false,
-            "map_public_ip_on_launch": false,
-            "outpost_arn": "",
-            "owner_id": "712023778557",
-            "private_dns_hostname_type_on_launch": "ip-name",
-            "tags": {
-              "Name": "test-stack-private-us-west-2b"
-            },
-            "tags_all": {
-              "Name": "test-stack-private-us-west-2b"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_subnet",
-      "name": "public",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-03e38b08477729e56",
-            "assign_ipv6_address_on_creation": true,
-            "availability_zone": "us-west-2a",
-            "availability_zone_id": "usw2-az2",
-            "cidr_block": "10.0.64.0/19",
-            "customer_owned_ipv4_pool": "",
-            "enable_dns64": false,
-            "enable_lni_at_device_index": 0,
-            "enable_resource_name_dns_a_record_on_launch": false,
-            "enable_resource_name_dns_aaaa_record_on_launch": true,
-            "id": "subnet-03e38b08477729e56",
-            "ipv6_cidr_block": "2600:1f14:34ee:ca00::/64",
-            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-0e4c03e1637f7da3a",
-            "ipv6_native": false,
-            "map_customer_owned_ip_on_launch": false,
-            "map_public_ip_on_launch": false,
-            "outpost_arn": "",
-            "owner_id": "712023778557",
-            "private_dns_hostname_type_on_launch": "ip-name",
-            "tags": {
-              "Name": "test-stack-public-us-west-2a"
-            },
-            "tags_all": {
-              "Name": "test-stack-public-us-west-2a"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-01f4f3ae425a408e5",
-            "assign_ipv6_address_on_creation": true,
-            "availability_zone": "us-west-2b",
-            "availability_zone_id": "usw2-az1",
-            "cidr_block": "10.0.192.0/19",
-            "customer_owned_ipv4_pool": "",
-            "enable_dns64": false,
-            "enable_lni_at_device_index": 0,
-            "enable_resource_name_dns_a_record_on_launch": false,
-            "enable_resource_name_dns_aaaa_record_on_launch": true,
-            "id": "subnet-01f4f3ae425a408e5",
-            "ipv6_cidr_block": "2600:1f14:34ee:ca01::/64",
-            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-0b58242851cade8a4",
-            "ipv6_native": false,
-            "map_customer_owned_ip_on_launch": false,
-            "map_public_ip_on_launch": false,
-            "outpost_arn": "",
-            "owner_id": "712023778557",
-            "private_dns_hostname_type_on_launch": "ip-name",
-            "tags": {
-              "Name": "test-stack-public-us-west-2b"
-            },
-            "tags_all": {
-              "Name": "test-stack-public-us-west-2b"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc",
-      "mode": "managed",
-      "type": "aws_subnet",
       "name": "redshift",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
@@ -2245,138 +1036,11 @@
     },
     {
       "module": "module.test_stack.module.vpc.module.vpc_endpoints",
-      "mode": "data",
-      "type": "aws_vpc_endpoint_service",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": "s3",
-          "schema_version": 0,
-          "attributes": {
-            "acceptance_required": false,
-            "arn": "arn:aws:ec2:us-west-2:712023778557:vpc-endpoint-service/vpce-svc-0001be97e1865c74e",
-            "availability_zones": [
-              "us-west-2a",
-              "us-west-2b",
-              "us-west-2c",
-              "us-west-2d"
-            ],
-            "base_endpoint_dns_names": [
-              "s3.us-west-2.amazonaws.com"
-            ],
-            "filter": [
-              {
-                "name": "service-type",
-                "values": [
-                  "Gateway"
-                ]
-              }
-            ],
-            "id": "526544209",
-            "manages_vpc_endpoints": false,
-            "owner": "amazon",
-            "private_dns_name": "",
-            "private_dns_names": [],
-            "region": "us-west-2",
-            "service": "s3",
-            "service_id": "vpce-svc-0001be97e1865c74e",
-            "service_name": "com.amazonaws.us-west-2.s3",
-            "service_regions": null,
-            "service_type": "Gateway",
-            "supported_ip_address_types": [
-              "ipv4"
-            ],
-            "tags": {},
-            "timeouts": null,
-            "vpc_endpoint_policy_supported": true
-          },
-          "sensitive_attributes": []
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc_endpoints",
       "mode": "managed",
       "type": "aws_security_group",
       "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.vpc.module.vpc_endpoints",
-      "mode": "managed",
-      "type": "aws_vpc_endpoint",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": "s3",
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:vpc-endpoint/vpce-032ad2a0b386b56ba",
-            "auto_accept": null,
-            "cidr_blocks": [
-              "3.5.76.0/22",
-              "3.5.80.0/21",
-              "18.34.48.0/20",
-              "18.34.244.0/22",
-              "52.92.128.0/17",
-              "52.218.128.0/17"
-            ],
-            "dns_entry": [],
-            "dns_options": [],
-            "id": "vpce-032ad2a0b386b56ba",
-            "ip_address_type": "",
-            "network_interface_ids": [],
-            "owner_id": "712023778557",
-            "policy": "{\"Statement\":[{\"Action\":\"*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"*\"}],\"Version\":\"2008-10-17\"}",
-            "prefix_list_id": "pl-68a54001",
-            "private_dns_enabled": false,
-            "requester_managed": false,
-            "resource_configuration_arn": "",
-            "route_table_ids": [
-              "rtb-05cb3223c3341fe67",
-              "rtb-06fe5396cbb825c57",
-              "rtb-0df3d3d3244e79288"
-            ],
-            "security_group_ids": [],
-            "service_name": "com.amazonaws.us-west-2.s3",
-            "service_network_arn": "",
-            "service_region": "",
-            "state": "available",
-            "subnet_configuration": [],
-            "subnet_ids": [],
-            "tags": {
-              "Name": "s3"
-            },
-            "tags_all": {
-              "Name": "s3"
-            },
-            "timeouts": {
-              "create": "10m",
-              "delete": "10m",
-              "update": "10m"
-            },
-            "vpc_endpoint_type": "Gateway",
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH19",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this",
-            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
-            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.private",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this",
-            "module.test_stack.module.vpc.module.vpc_endpoints.aws_security_group.this",
-            "module.test_stack.module.vpc.module.vpc_endpoints.data.aws_vpc_endpoint_service.this"
-          ]
-        }
-      ]
     }
   ],
   "check_results": null

--- a/tests/terraform.tfstate
+++ b/tests/terraform.tfstate
@@ -1,92 +1,10 @@
 {
   "version": 4,
   "terraform_version": "1.5.7",
-  "serial": 107,
+  "serial": 121,
   "lineage": "75bcca89-5908-83ac-242d-e07d23acebcc",
-  "outputs": {
-    "test_common_tags": {
-      "value": true,
-      "type": "bool"
-    }
-  },
+  "outputs": {},
   "resources": [
-    {
-      "module": "module.test_stack.module.db.module.db",
-      "mode": "managed",
-      "type": "random_password",
-      "name": "master_password",
-      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 3,
-          "attributes": {
-            "bcrypt_hash": "$2a$10$OC2TmGdShbULQ8wyvYEQ9enlOrrzTyGrLjH28C9TjYDMVIW6ZeGrS",
-            "id": "none",
-            "keepers": null,
-            "length": 16,
-            "lower": true,
-            "min_lower": 0,
-            "min_numeric": 0,
-            "min_special": 0,
-            "min_upper": 0,
-            "number": true,
-            "numeric": true,
-            "override_special": null,
-            "result": "vADu1f7Yql0OEHoI",
-            "special": false,
-            "upper": true
-          },
-          "sensitive_attributes": []
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.db.module.db.module.db_instance",
-      "mode": "data",
-      "type": "aws_iam_policy_document",
-      "name": "enhanced_monitoring",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "id": "76086537",
-            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"monitoring.rds.amazonaws.com\"\n      }\n    }\n  ]\n}",
-            "minified_json": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"monitoring.rds.amazonaws.com\"}}]}",
-            "override_json": null,
-            "override_policy_documents": null,
-            "policy_id": null,
-            "source_json": null,
-            "source_policy_documents": null,
-            "statement": [
-              {
-                "actions": [
-                  "sts:AssumeRole"
-                ],
-                "condition": [],
-                "effect": "Allow",
-                "not_actions": [],
-                "not_principals": [],
-                "not_resources": [],
-                "principals": [
-                  {
-                    "identifiers": [
-                      "monitoring.rds.amazonaws.com"
-                    ],
-                    "type": "Service"
-                  }
-                ],
-                "resources": [],
-                "sid": ""
-              }
-            ],
-            "version": "2012-10-17"
-          },
-          "sensitive_attributes": []
-        }
-      ]
-    },
     {
       "module": "module.test_stack.module.db.module.db.module.db_instance",
       "mode": "managed",
@@ -98,168 +16,10 @@
     {
       "module": "module.test_stack.module.db.module.db.module.db_instance",
       "mode": "managed",
-      "type": "aws_db_instance",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "status": "tainted",
-          "schema_version": 2,
-          "attributes": {
-            "address": "test-stack.cz5fnzdopp73.us-west-2.rds.amazonaws.com",
-            "allocated_storage": 100,
-            "allow_major_version_upgrade": true,
-            "apply_immediately": true,
-            "arn": "arn:aws:rds:us-west-2:712023778557:db:test-stack",
-            "auto_minor_version_upgrade": false,
-            "availability_zone": "us-west-2a",
-            "backup_retention_period": 7,
-            "backup_target": "region",
-            "backup_window": "08:06-08:36",
-            "blue_green_update": [],
-            "ca_cert_identifier": "rds-ca-rsa2048-g1",
-            "character_set_name": "",
-            "copy_tags_to_snapshot": false,
-            "custom_iam_instance_profile": "",
-            "customer_owned_ip_enabled": false,
-            "database_insights_mode": "standard",
-            "db_name": "quilt",
-            "db_subnet_group_name": "test-stack-2025042300264134470000000c",
-            "dedicated_log_volume": false,
-            "delete_automated_backups": true,
-            "deletion_protection": false,
-            "domain": "",
-            "domain_auth_secret_arn": "",
-            "domain_dns_ips": [],
-            "domain_fqdn": "",
-            "domain_iam_role_name": "",
-            "domain_ou": "",
-            "enabled_cloudwatch_logs_exports": [],
-            "endpoint": "test-stack.cz5fnzdopp73.us-west-2.rds.amazonaws.com:5432",
-            "engine": "postgres",
-            "engine_lifecycle_support": "open-source-rds-extended-support",
-            "engine_version": "15.12",
-            "engine_version_actual": "15.12",
-            "final_snapshot_identifier": "final-test-stack-26a37146",
-            "hosted_zone_id": "Z1PVIF0B656C1W",
-            "iam_database_authentication_enabled": false,
-            "id": "db-HZQXH5YHJUDJWVIED2A26PDVYU",
-            "identifier": "test-stack",
-            "identifier_prefix": "",
-            "instance_class": "db.t3.small",
-            "iops": 0,
-            "kms_key_id": "arn:aws:kms:us-west-2:712023778557:key/e0b18d55-3f79-45ea-8081-7f363c0d0728",
-            "latest_restorable_time": "2025-04-23T02:44:35Z",
-            "license_model": "postgresql-license",
-            "listener_endpoint": [],
-            "maintenance_window": "fri:12:06-fri:12:36",
-            "manage_master_user_password": null,
-            "master_user_secret": [],
-            "master_user_secret_kms_key_id": null,
-            "max_allocated_storage": 0,
-            "monitoring_interval": 0,
-            "monitoring_role_arn": "",
-            "multi_az": true,
-            "nchar_character_set_name": "",
-            "network_type": "DUAL",
-            "option_group_name": "default:postgres-15",
-            "parameter_group_name": "default.postgres15",
-            "password": "vADu1f7Yql0OEHoI",
-            "password_wo": null,
-            "password_wo_version": null,
-            "performance_insights_enabled": false,
-            "performance_insights_kms_key_id": "",
-            "performance_insights_retention_period": 0,
-            "port": 5432,
-            "publicly_accessible": false,
-            "replica_mode": "",
-            "replicas": [],
-            "replicate_source_db": "",
-            "resource_id": "db-HZQXH5YHJUDJWVIED2A26PDVYU",
-            "restore_to_point_in_time": [],
-            "s3_import": [],
-            "skip_final_snapshot": false,
-            "snapshot_identifier": null,
-            "status": "available",
-            "storage_encrypted": true,
-            "storage_throughput": 0,
-            "storage_type": "gp2",
-            "tags": {},
-            "tags_all": {},
-            "timeouts": {
-              "create": null,
-              "delete": null,
-              "update": null
-            },
-            "timezone": "",
-            "upgrade_storage_config": null,
-            "username": "root",
-            "vpc_security_group_ids": [
-              "sg-020314c863db902e1"
-            ]
-          },
-          "sensitive_attributes": [
-            [
-              {
-                "type": "get_attr",
-                "value": "password"
-              }
-            ]
-          ],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInVwZGF0ZSI6NDgwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMiJ9",
-          "dependencies": [
-            "module.test_stack.module.db.module.db.module.db_instance.aws_cloudwatch_log_group.this",
-            "module.test_stack.module.db.module.db.module.db_instance.aws_iam_role.enhanced_monitoring",
-            "module.test_stack.module.db.module.db.module.db_instance.data.aws_iam_policy_document.enhanced_monitoring",
-            "module.test_stack.module.db.module.db.module.db_instance.random_id.snapshot_identifier",
-            "module.test_stack.module.db.module.db.module.db_option_group.aws_db_option_group.this",
-            "module.test_stack.module.db.module.db.module.db_parameter_group.aws_db_parameter_group.this",
-            "module.test_stack.module.db.module.db.module.db_subnet_group.aws_db_subnet_group.this",
-            "module.test_stack.module.db.module.db.random_password.master_password",
-            "module.test_stack.module.db.module.db_security_group.aws_security_group.this",
-            "module.test_stack.module.db.module.db_security_group.aws_security_group.this_name_prefix",
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
-    },
-    {
-      "module": "module.test_stack.module.db.module.db.module.db_instance",
-      "mode": "managed",
       "type": "aws_iam_role",
       "name": "enhanced_monitoring",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.db.module.db.module.db_instance",
-      "mode": "managed",
-      "type": "random_id",
-      "name": "snapshot_identifier",
-      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "b64_std": "JqNxRg==",
-            "b64_url": "JqNxRg",
-            "byte_length": 4,
-            "dec": "648245574",
-            "hex": "26a37146",
-            "id": "JqNxRg",
-            "keepers": {
-              "id": "test-stack"
-            },
-            "prefix": null
-          },
-          "sensitive_attributes": []
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.db.module.db.module.db_option_group",
@@ -276,49 +36,6 @@
       "name": "this",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": []
-    },
-    {
-      "module": "module.test_stack.module.db.module.db.module.db_subnet_group",
-      "mode": "managed",
-      "type": "aws_db_subnet_group",
-      "name": "this",
-      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
-      "instances": [
-        {
-          "index_key": 0,
-          "schema_version": 0,
-          "attributes": {
-            "arn": "arn:aws:rds:us-west-2:712023778557:subgrp:test-stack-2025042300264134470000000c",
-            "description": "test-stack subnet group",
-            "id": "test-stack-2025042300264134470000000c",
-            "name": "test-stack-2025042300264134470000000c",
-            "name_prefix": "test-stack-",
-            "subnet_ids": [
-              "subnet-06f7cbe14df00ee8c",
-              "subnet-0b2f3f527ac76bc61"
-            ],
-            "supported_network_types": [
-              "DUAL",
-              "IPV4"
-            ],
-            "tags": {
-              "Name": "test-stack"
-            },
-            "tags_all": {
-              "Name": "test-stack"
-            },
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "bnVsbA==",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
-        }
-      ]
     },
     {
       "module": "module.test_stack.module.db.module.db_accessor_security_group",
@@ -714,46 +431,6 @@
             "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
             "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
           ]
-        },
-        {
-          "index_key": 1,
-          "schema_version": 1,
-          "attributes": {
-            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-06f7cbe14df00ee8c",
-            "assign_ipv6_address_on_creation": true,
-            "availability_zone": "us-west-2b",
-            "availability_zone_id": "usw2-az1",
-            "cidr_block": "10.0.224.0/20",
-            "customer_owned_ipv4_pool": "",
-            "enable_dns64": false,
-            "enable_lni_at_device_index": 0,
-            "enable_resource_name_dns_a_record_on_launch": false,
-            "enable_resource_name_dns_aaaa_record_on_launch": true,
-            "id": "subnet-06f7cbe14df00ee8c",
-            "ipv6_cidr_block": "2600:1f14:34ee:ca05::/64",
-            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-089225e3ba974d7fd",
-            "ipv6_native": false,
-            "map_customer_owned_ip_on_launch": false,
-            "map_public_ip_on_launch": false,
-            "outpost_arn": "",
-            "owner_id": "712023778557",
-            "private_dns_hostname_type_on_launch": "ip-name",
-            "tags": {
-              "Name": "test-stack-intra-us-west-2b"
-            },
-            "tags_all": {
-              "Name": "test-stack-intra-us-west-2b"
-            },
-            "timeouts": null,
-            "vpc_id": "vpc-08a6cfe215aa111d2"
-          },
-          "sensitive_attributes": [],
-          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
-          "dependencies": [
-            "module.test_stack.module.vpc.data.aws_availability_zones.available",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
-            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
-          ]
         }
       ]
     },
@@ -867,5 +544,12 @@
       "instances": []
     }
   ],
-  "check_results": null
+  "check_results": [
+    {
+      "object_kind": "output",
+      "config_addr": "module.test_stack.module.vpc.output.configuration_error",
+      "status": "unknown",
+      "objects": null
+    }
+  ]
 }

--- a/tests/terraform.tfstate
+++ b/tests/terraform.tfstate
@@ -1,0 +1,2383 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.7",
+  "serial": 47,
+  "lineage": "75bcca89-5908-83ac-242d-e07d23acebcc",
+  "outputs": {
+    "test_common_tags": {
+      "value": true,
+      "type": "bool"
+    }
+  },
+  "resources": [
+    {
+      "module": "module.test_stack",
+      "mode": "managed",
+      "type": "aws_cloudformation_stack",
+      "name": "stack",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "cft_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::quilt-templates-test-stack-20250423002555455000000001",
+            "bucket": "quilt-templates-test-stack-20250423002555455000000001",
+            "bucket_domain_name": "quilt-templates-test-stack-20250423002555455000000001.s3.amazonaws.com",
+            "bucket_prefix": "quilt-templates-test-stack-",
+            "bucket_regional_domain_name": "quilt-templates-test-stack-20250423002555455000000001.s3.us-west-2.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": true,
+            "grant": [
+              {
+                "id": "b035c754b9182851f427b323faff3cde0f4a6f6ce0bc0ea7fde56948b8386a20",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3BJ6K6RIION7M",
+            "id": "quilt-templates-test-stack-20250423002555455000000001",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-west-2",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {
+              "quilt:stack-name": "test-stack"
+            },
+            "tags_all": {
+              "quilt:stack-name": "test-stack"
+            },
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjM2MDAwMDAwMDAwMDAsInJlYWQiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack",
+      "mode": "managed",
+      "type": "aws_s3_bucket_versioning",
+      "name": "cft_bucket_versioning",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "quilt-templates-test-stack-20250423002555455000000001",
+            "expected_bucket_owner": "",
+            "id": "quilt-templates-test-stack-20250423002555455000000001",
+            "mfa": null,
+            "versioning_configuration": [
+              {
+                "mfa_delete": "",
+                "status": "Enabled"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.test_stack.aws_s3_bucket.cft_bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack",
+      "mode": "managed",
+      "type": "aws_s3_object",
+      "name": "cft",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acl": null,
+            "arn": "arn:aws:s3:::quilt-templates-test-stack-20250423002555455000000001/quilt.yaml",
+            "bucket": "quilt-templates-test-stack-20250423002555455000000001",
+            "bucket_key_enabled": false,
+            "cache_control": "",
+            "checksum_algorithm": null,
+            "checksum_crc32": "",
+            "checksum_crc32c": "",
+            "checksum_crc64nvme": "",
+            "checksum_sha1": "",
+            "checksum_sha256": "",
+            "content": null,
+            "content_base64": null,
+            "content_disposition": "",
+            "content_encoding": "",
+            "content_language": "",
+            "content_type": "application/octet-stream",
+            "etag": "7a684fe1081285d879cc3349d1cf6f5f",
+            "force_destroy": false,
+            "id": "quilt.yaml",
+            "key": "quilt.yaml",
+            "kms_key_id": null,
+            "metadata": null,
+            "object_lock_legal_hold_status": "",
+            "object_lock_mode": "",
+            "object_lock_retain_until_date": "",
+            "override_provider": [],
+            "server_side_encryption": "AES256",
+            "source": "./test.yml",
+            "source_hash": null,
+            "storage_class": "STANDARD",
+            "tags": null,
+            "tags_all": {},
+            "version_id": "8oDqK42lzSykoZR8.frzrhqlY6Ho92m6",
+            "website_redirect": ""
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.test_stack.aws_s3_bucket.cft_bucket"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack",
+      "mode": "managed",
+      "type": "random_password",
+      "name": "admin_password",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 3,
+          "attributes": {
+            "bcrypt_hash": "$2a$10$Ak8ixWvbquGVqNBpyYD3tedQxC/t0qKsX9SGqZnozozTFENj0dMY.",
+            "id": "none",
+            "keepers": null,
+            "length": 16,
+            "lower": true,
+            "min_lower": 0,
+            "min_numeric": 0,
+            "min_special": 0,
+            "min_upper": 0,
+            "number": true,
+            "numeric": true,
+            "override_special": null,
+            "result": "GAVBFgD\u003ezV:$C_7J",
+            "special": true,
+            "upper": true
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db",
+      "mode": "managed",
+      "type": "random_password",
+      "name": "master_password",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 3,
+          "attributes": {
+            "bcrypt_hash": "$2a$10$OC2TmGdShbULQ8wyvYEQ9enlOrrzTyGrLjH28C9TjYDMVIW6ZeGrS",
+            "id": "none",
+            "keepers": null,
+            "length": 16,
+            "lower": true,
+            "min_lower": 0,
+            "min_numeric": 0,
+            "min_special": 0,
+            "min_upper": 0,
+            "number": true,
+            "numeric": true,
+            "override_special": null,
+            "result": "vADu1f7Yql0OEHoI",
+            "special": false,
+            "upper": true
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_instance",
+      "mode": "data",
+      "type": "aws_iam_policy_document",
+      "name": "enhanced_monitoring",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "76086537",
+            "json": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"monitoring.rds.amazonaws.com\"\n      }\n    }\n  ]\n}",
+            "minified_json": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"monitoring.rds.amazonaws.com\"}}]}",
+            "override_json": null,
+            "override_policy_documents": null,
+            "policy_id": null,
+            "source_json": null,
+            "source_policy_documents": null,
+            "statement": [
+              {
+                "actions": [
+                  "sts:AssumeRole"
+                ],
+                "condition": [],
+                "effect": "Allow",
+                "not_actions": [],
+                "not_principals": [],
+                "not_resources": [],
+                "principals": [
+                  {
+                    "identifiers": [
+                      "monitoring.rds.amazonaws.com"
+                    ],
+                    "type": "Service"
+                  }
+                ],
+                "resources": [],
+                "sid": ""
+              }
+            ],
+            "version": "2012-10-17"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_instance",
+      "mode": "data",
+      "type": "aws_partition",
+      "name": "current",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "dns_suffix": "amazonaws.com",
+            "id": "aws",
+            "partition": "aws",
+            "reverse_dns_prefix": "com.amazonaws"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_instance",
+      "mode": "managed",
+      "type": "aws_cloudwatch_log_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_instance",
+      "mode": "managed",
+      "type": "aws_db_instance",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_instance",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "enhanced_monitoring",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_instance",
+      "mode": "managed",
+      "type": "random_id",
+      "name": "snapshot_identifier",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "b64_std": "JqNxRg==",
+            "b64_url": "JqNxRg",
+            "byte_length": 4,
+            "dec": "648245574",
+            "hex": "26a37146",
+            "id": "JqNxRg",
+            "keepers": {
+              "id": "test-stack"
+            },
+            "prefix": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_option_group",
+      "mode": "managed",
+      "type": "aws_db_option_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_parameter_group",
+      "mode": "managed",
+      "type": "aws_db_parameter_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db.module.db_subnet_group",
+      "mode": "managed",
+      "type": "aws_db_subnet_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:rds:us-west-2:712023778557:subgrp:test-stack-2025042300264134470000000c",
+            "description": "test-stack subnet group",
+            "id": "test-stack-2025042300264134470000000c",
+            "name": "test-stack-2025042300264134470000000c",
+            "name_prefix": "test-stack-",
+            "subnet_ids": [
+              "subnet-06f7cbe14df00ee8c",
+              "subnet-0b2f3f527ac76bc61"
+            ],
+            "supported_network_types": [
+              "DUAL",
+              "IPV4"
+            ],
+            "tags": {
+              "Name": "test-stack"
+            },
+            "tags_all": {
+              "Name": "test-stack"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db_accessor_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db_accessor_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this_name_prefix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0d87f94feb586d008",
+            "description": "For resources that need access to DB",
+            "egress": [],
+            "id": "sg-0d87f94feb586d008",
+            "ingress": [],
+            "name": "test-stack-db-accessor-2025042300262208060000000a",
+            "name_prefix": "test-stack-db-accessor-",
+            "owner_id": "712023778557",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "test-stack-db-accessor"
+            },
+            "tags_all": {
+              "Name": "test-stack-db-accessor"
+            },
+            "timeouts": {
+              "create": "10m",
+              "delete": "15m"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db_accessor_security_group",
+      "mode": "managed",
+      "type": "aws_security_group_rule",
+      "name": "egress_with_source_security_group_id",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 2,
+          "attributes": {
+            "cidr_blocks": null,
+            "description": "Egress Rule",
+            "from_port": 5432,
+            "id": "sgrule-3619442631",
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_group_id": "sg-0d87f94feb586d008",
+            "security_group_rule_id": "sgr-0b5c4119aa3ccefa3",
+            "self": false,
+            "source_security_group_id": "sg-020314c863db902e1",
+            "timeouts": null,
+            "to_port": 5432,
+            "type": "egress"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this",
+            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.db.module.db_security_group.aws_security_group.this",
+            "module.test_stack.module.db.module.db_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.db.module.db_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this_name_prefix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-020314c863db902e1",
+            "description": "For DB resources",
+            "egress": [],
+            "id": "sg-020314c863db902e1",
+            "ingress": [],
+            "name": "test-stack-db-2025042300262363030000000b",
+            "name_prefix": "test-stack-db-",
+            "owner_id": "712023778557",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "test-stack-db"
+            },
+            "tags_all": {
+              "Name": "test-stack-db"
+            },
+            "timeouts": {
+              "create": "10m",
+              "delete": "15m"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.db.module.db_security_group",
+      "mode": "managed",
+      "type": "aws_security_group_rule",
+      "name": "ingress_with_source_security_group_id",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 2,
+          "attributes": {
+            "cidr_blocks": null,
+            "description": "Ingress Rule",
+            "from_port": 5432,
+            "id": "sgrule-1154694529",
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_group_id": "sg-020314c863db902e1",
+            "security_group_rule_id": "sgr-02144ce34846605a9",
+            "self": false,
+            "source_security_group_id": "sg-0d87f94feb586d008",
+            "timeouts": null,
+            "to_port": 5432,
+            "type": "ingress"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this",
+            "module.test_stack.module.db.module.db_accessor_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.db.module.db_security_group.aws_security_group.this",
+            "module.test_stack.module.db.module.db_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.search",
+      "mode": "managed",
+      "type": "aws_elasticsearch_domain",
+      "name": "search",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.search.module.search_accessor_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.search.module.search_accessor_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this_name_prefix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-057b092de0195c491",
+            "description": "For resources that need access to search cluster",
+            "egress": [],
+            "id": "sg-057b092de0195c491",
+            "ingress": [],
+            "name": "test-stack-search-accessor-20250423002621511800000008",
+            "name_prefix": "test-stack-search-accessor-",
+            "owner_id": "712023778557",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "test-stack-search-accessor"
+            },
+            "tags_all": {
+              "Name": "test-stack-search-accessor"
+            },
+            "timeouts": {
+              "create": "10m",
+              "delete": "15m"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.search.module.search_accessor_security_group",
+      "mode": "managed",
+      "type": "aws_security_group_rule",
+      "name": "egress_with_source_security_group_id",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 2,
+          "attributes": {
+            "cidr_blocks": null,
+            "description": "Egress Rule",
+            "from_port": 443,
+            "id": "sgrule-1712243089",
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_group_id": "sg-057b092de0195c491",
+            "security_group_rule_id": "sgr-01dabe1817e4c4658",
+            "self": false,
+            "source_security_group_id": "sg-0a4171800b5592e57",
+            "timeouts": null,
+            "to_port": 443,
+            "type": "egress"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this",
+            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.search.module.search_security_group.aws_security_group.this",
+            "module.test_stack.module.search.module.search_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.search.module.search_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.search.module.search_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this_name_prefix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0a4171800b5592e57",
+            "description": "For search cluster resources",
+            "egress": [],
+            "id": "sg-0a4171800b5592e57",
+            "ingress": [],
+            "name": "test-stack-search-20250423002621879500000009",
+            "name_prefix": "test-stack-search-",
+            "owner_id": "712023778557",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "test-stack-search"
+            },
+            "tags_all": {
+              "Name": "test-stack-search"
+            },
+            "timeouts": {
+              "create": "10m",
+              "delete": "15m"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.search.module.search_security_group",
+      "mode": "managed",
+      "type": "aws_security_group_rule",
+      "name": "ingress_with_source_security_group_id",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 2,
+          "attributes": {
+            "cidr_blocks": null,
+            "description": "Ingress Rule",
+            "from_port": 443,
+            "id": "sgrule-2113705527",
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_group_id": "sg-0a4171800b5592e57",
+            "security_group_rule_id": "sgr-02ffb2290680ae40c",
+            "self": false,
+            "source_security_group_id": "sg-057b092de0195c491",
+            "timeouts": null,
+            "to_port": 443,
+            "type": "ingress"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this",
+            "module.test_stack.module.search.module.search_accessor_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.search.module.search_security_group.aws_security_group.this",
+            "module.test_stack.module.search.module.search_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc",
+      "mode": "data",
+      "type": "aws_availability_zones",
+      "name": "available",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "all_availability_zones": null,
+            "exclude_names": null,
+            "exclude_zone_ids": null,
+            "filter": null,
+            "group_names": [
+              "us-west-2-zg-1"
+            ],
+            "id": "us-west-2",
+            "names": [
+              "us-west-2a",
+              "us-west-2b",
+              "us-west-2c",
+              "us-west-2d"
+            ],
+            "state": "available",
+            "timeouts": null,
+            "zone_ids": [
+              "usw2-az2",
+              "usw2-az1",
+              "usw2-az3",
+              "usw2-az4"
+            ]
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.api_gateway_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.api_gateway_security_group",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this_name_prefix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0dfa77448bfa8ca1b",
+            "description": "User ingress security group for API Gateway Endpoint, Quilt load balancer",
+            "egress": [],
+            "id": "sg-0dfa77448bfa8ca1b",
+            "ingress": [],
+            "name": "test-stack-user-ingress-20250423002621281500000007",
+            "name_prefix": "test-stack-user-ingress-",
+            "owner_id": "712023778557",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "test-stack-user-ingress"
+            },
+            "tags_all": {
+              "Name": "test-stack-user-ingress"
+            },
+            "timeouts": {
+              "create": "10m",
+              "delete": "15m"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0=",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ],
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.api_gateway_security_group",
+      "mode": "managed",
+      "type": "aws_security_group_rule",
+      "name": "ingress_rules",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 2,
+          "attributes": {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "HTTPS",
+            "from_port": 443,
+            "id": "sgrule-2647011336",
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_group_id": "sg-0dfa77448bfa8ca1b",
+            "security_group_rule_id": "sgr-003839800c12cd55a",
+            "self": false,
+            "source_security_group_id": null,
+            "timeouts": null,
+            "to_port": 443,
+            "type": "ingress"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this",
+            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 2,
+          "attributes": {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "HTTP",
+            "from_port": 80,
+            "id": "sgrule-3431647834",
+            "ipv6_cidr_blocks": [],
+            "prefix_list_ids": [],
+            "protocol": "tcp",
+            "security_group_id": "sg-0dfa77448bfa8ca1b",
+            "security_group_rule_id": "sgr-0c48cb5b5745ba17e",
+            "self": false,
+            "source_security_group_id": null,
+            "timeouts": null,
+            "to_port": 80,
+            "type": "ingress"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this",
+            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_cloudwatch_log_group",
+      "name": "flow_log",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_customer_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_db_subnet_group",
+      "name": "database",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_default_network_acl",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:network-acl/acl-03e9a45c813025712",
+            "default_network_acl_id": "acl-03e9a45c813025712",
+            "egress": [
+              {
+                "action": "allow",
+                "cidr_block": "",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "::/0",
+                "protocol": "-1",
+                "rule_no": 101,
+                "to_port": 0
+              },
+              {
+                "action": "allow",
+                "cidr_block": "0.0.0.0/0",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "",
+                "protocol": "-1",
+                "rule_no": 100,
+                "to_port": 0
+              }
+            ],
+            "id": "acl-03e9a45c813025712",
+            "ingress": [
+              {
+                "action": "allow",
+                "cidr_block": "",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "::/0",
+                "protocol": "-1",
+                "rule_no": 101,
+                "to_port": 0
+              },
+              {
+                "action": "allow",
+                "cidr_block": "0.0.0.0/0",
+                "from_port": 0,
+                "icmp_code": null,
+                "icmp_type": null,
+                "ipv6_cidr_block": "",
+                "protocol": "-1",
+                "rule_no": 100,
+                "to_port": 0
+              }
+            ],
+            "owner_id": "712023778557",
+            "subnet_ids": [
+              "subnet-01f4f3ae425a408e5",
+              "subnet-06f7cbe14df00ee8c",
+              "subnet-0850b8f168c863fbb",
+              "subnet-0b2f3f527ac76bc61",
+              "subnet-0d9b23c7315330852"
+            ],
+            "tags": {
+              "Name": "test-stack-default"
+            },
+            "tags_all": {
+              "Name": "test-stack-default"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_default_route_table",
+      "name": "default",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-0dca290699431a6a1",
+            "default_route_table_id": "rtb-0dca290699431a6a1",
+            "id": "rtb-0dca290699431a6a1",
+            "owner_id": "712023778557",
+            "propagating_vgws": null,
+            "route": [],
+            "tags": {
+              "Name": "test-stack-default"
+            },
+            "tags_all": {
+              "Name": "test-stack-default"
+            },
+            "timeouts": {
+              "create": "5m",
+              "update": "5m"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsInVwZGF0ZSI6MzAwMDAwMDAwMDAwfX0=",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_default_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:security-group/sg-0c866a5d608a24b01",
+            "description": "default VPC security group",
+            "egress": [],
+            "id": "sg-0c866a5d608a24b01",
+            "ingress": [],
+            "name": "default",
+            "name_prefix": "",
+            "owner_id": "712023778557",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "test-stack-default"
+            },
+            "tags_all": {
+              "Name": "test-stack-default"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_default_vpc",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_egress_only_internet_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "id": "eigw-007a5419e6f24aac3",
+            "tags": {
+              "Name": "test-stack"
+            },
+            "tags_all": {
+              "Name": "test-stack"
+            },
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "nat",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "address": null,
+            "allocation_id": "eipalloc-04bcf73b1477b83a0",
+            "arn": "arn:aws:ec2:us-west-2:712023778557:elastic-ip/eipalloc-04bcf73b1477b83a0",
+            "associate_with_private_ip": null,
+            "association_id": "",
+            "carrier_ip": "",
+            "customer_owned_ip": "",
+            "customer_owned_ipv4_pool": "",
+            "domain": "vpc",
+            "id": "eipalloc-04bcf73b1477b83a0",
+            "instance": "",
+            "ipam_pool_id": null,
+            "network_border_group": "us-west-2",
+            "network_interface": "",
+            "private_dns": null,
+            "private_ip": "",
+            "ptr_record": "",
+            "public_dns": "ec2-54-190-19-19.us-west-2.compute.amazonaws.com",
+            "public_ip": "54.190.19.19",
+            "public_ipv4_pool": "amazon",
+            "tags": {
+              "Name": "test-stack-us-west-2b"
+            },
+            "tags_all": {
+              "Name": "test-stack-us-west-2b"
+            },
+            "timeouts": null,
+            "vpc": true
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxODAwMDAwMDAwMDAsInJlYWQiOjkwMDAwMDAwMDAwMCwidXBkYXRlIjozMDAwMDAwMDAwMDB9fQ==",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_internet_gateway.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_elasticache_subnet_group",
+      "name": "elasticache",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_flow_log",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "vpc_flow_log_cloudwatch",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:internet-gateway/igw-0eb692813ce15f3a7",
+            "id": "igw-0eb692813ce15f3a7",
+            "owner_id": "712023778557",
+            "tags": {
+              "Name": "test-stack"
+            },
+            "tags_all": {
+              "Name": "test-stack"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_nat_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "database",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "elasticache",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "intra",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "outpost",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_network_acl",
+      "name": "redshift",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_redshift_subnet_group",
+      "name": "redshift",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "database_internet_gateway",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "database_ipv6_egress",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "database_nat_gateway",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "private_ipv6_egress",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "carrier_gateway_id": "",
+            "core_network_arn": "",
+            "destination_cidr_block": "",
+            "destination_ipv6_cidr_block": "::/0",
+            "destination_prefix_list_id": "",
+            "egress_only_gateway_id": "eigw-007a5419e6f24aac3",
+            "gateway_id": "",
+            "id": "r-rtb-0df3d3d3244e792882750132062",
+            "instance_id": "",
+            "instance_owner_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "",
+            "network_interface_id": "",
+            "origin": "CreateRoute",
+            "route_table_id": "rtb-0df3d3d3244e79288",
+            "state": "active",
+            "timeouts": null,
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_egress_only_internet_gateway.this",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "carrier_gateway_id": "",
+            "core_network_arn": "",
+            "destination_cidr_block": "",
+            "destination_ipv6_cidr_block": "::/0",
+            "destination_prefix_list_id": "",
+            "egress_only_gateway_id": "eigw-007a5419e6f24aac3",
+            "gateway_id": "",
+            "id": "r-rtb-05cb3223c3341fe672750132062",
+            "instance_id": "",
+            "instance_owner_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "",
+            "network_interface_id": "",
+            "origin": "CreateRoute",
+            "route_table_id": "rtb-05cb3223c3341fe67",
+            "state": "active",
+            "timeouts": null,
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_egress_only_internet_gateway.this",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "private_nat_gateway",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "public_internet_gateway",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "carrier_gateway_id": "",
+            "core_network_arn": "",
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": "",
+            "destination_prefix_list_id": "",
+            "egress_only_gateway_id": "",
+            "gateway_id": "igw-0eb692813ce15f3a7",
+            "id": "r-rtb-06fe5396cbb825c571080289494",
+            "instance_id": "",
+            "instance_owner_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "",
+            "network_interface_id": "",
+            "origin": "CreateRoute",
+            "route_table_id": "rtb-06fe5396cbb825c57",
+            "state": "active",
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_internet_gateway.this",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route",
+      "name": "public_internet_gateway_ipv6",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "carrier_gateway_id": "",
+            "core_network_arn": "",
+            "destination_cidr_block": "",
+            "destination_ipv6_cidr_block": "::/0",
+            "destination_prefix_list_id": "",
+            "egress_only_gateway_id": "",
+            "gateway_id": "igw-0eb692813ce15f3a7",
+            "id": "r-rtb-06fe5396cbb825c572750132062",
+            "instance_id": "",
+            "instance_owner_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "",
+            "network_interface_id": "",
+            "origin": "CreateRoute",
+            "route_table_id": "rtb-06fe5396cbb825c57",
+            "state": "active",
+            "timeouts": null,
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_internet_gateway.this",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "database",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "elasticache",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "intra",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-0905294eb9954fb2c",
+            "id": "rtb-0905294eb9954fb2c",
+            "owner_id": "712023778557",
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {
+              "Name": "test-stack-intra"
+            },
+            "tags_all": {
+              "Name": "test-stack-intra"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-0df3d3d3244e79288",
+            "id": "rtb-0df3d3d3244e79288",
+            "owner_id": "712023778557",
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {
+              "Name": "test-stack-private-us-west-2a"
+            },
+            "tags_all": {
+              "Name": "test-stack-private-us-west-2a"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-05cb3223c3341fe67",
+            "id": "rtb-05cb3223c3341fe67",
+            "owner_id": "712023778557",
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {
+              "Name": "test-stack-private-us-west-2b"
+            },
+            "tags_all": {
+              "Name": "test-stack-private-us-west-2b"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:route-table/rtb-06fe5396cbb825c57",
+            "id": "rtb-06fe5396cbb825c57",
+            "owner_id": "712023778557",
+            "propagating_vgws": [],
+            "route": [],
+            "tags": {
+              "Name": "test-stack-public"
+            },
+            "tags_all": {
+              "Name": "test-stack-public"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "redshift",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "database",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "elasticache",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "intra",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-0acc9582ba89420f7",
+            "route_table_id": "rtb-0905294eb9954fb2c",
+            "subnet_id": "subnet-0b2f3f527ac76bc61",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-023485c5a70dc3388",
+            "route_table_id": "rtb-0905294eb9954fb2c",
+            "subnet_id": "subnet-06f7cbe14df00ee8c",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.intra",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-0d1a7d33f547403e0",
+            "route_table_id": "rtb-0df3d3d3244e79288",
+            "subnet_id": "subnet-0850b8f168c863fbb",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.private",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-04bae89e981642fea",
+            "route_table_id": "rtb-05cb3223c3341fe67",
+            "subnet_id": "subnet-0d9b23c7315330852",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.private",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-0b7eb8d1f513b38ad",
+            "route_table_id": "rtb-06fe5396cbb825c57",
+            "subnet_id": "subnet-03e38b08477729e56",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.public",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-004aadc43aec3ea10",
+            "route_table_id": "rtb-06fe5396cbb825c57",
+            "subnet_id": "subnet-01f4f3ae425a408e5",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.public",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "redshift",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "redshift_public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "database",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "elasticache",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "intra",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-0b2f3f527ac76bc61",
+            "assign_ipv6_address_on_creation": true,
+            "availability_zone": "us-west-2a",
+            "availability_zone_id": "usw2-az2",
+            "cidr_block": "10.0.96.0/20",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": true,
+            "id": "subnet-0b2f3f527ac76bc61",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca04::/64",
+            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-04e11fc3a54f7c5c7",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "712023778557",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "test-stack-intra-us-west-2a"
+            },
+            "tags_all": {
+              "Name": "test-stack-intra-us-west-2a"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-06f7cbe14df00ee8c",
+            "assign_ipv6_address_on_creation": true,
+            "availability_zone": "us-west-2b",
+            "availability_zone_id": "usw2-az1",
+            "cidr_block": "10.0.224.0/20",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": true,
+            "id": "subnet-06f7cbe14df00ee8c",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca05::/64",
+            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-089225e3ba974d7fd",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "712023778557",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "test-stack-intra-us-west-2b"
+            },
+            "tags_all": {
+              "Name": "test-stack-intra-us-west-2b"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "outpost",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-0850b8f168c863fbb",
+            "assign_ipv6_address_on_creation": true,
+            "availability_zone": "us-west-2a",
+            "availability_zone_id": "usw2-az2",
+            "cidr_block": "10.0.0.0/18",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": true,
+            "id": "subnet-0850b8f168c863fbb",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca02::/64",
+            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-08ad55c85e0a22c75",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "712023778557",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "test-stack-private-us-west-2a"
+            },
+            "tags_all": {
+              "Name": "test-stack-private-us-west-2a"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-0d9b23c7315330852",
+            "assign_ipv6_address_on_creation": true,
+            "availability_zone": "us-west-2b",
+            "availability_zone_id": "usw2-az1",
+            "cidr_block": "10.0.128.0/18",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": true,
+            "id": "subnet-0d9b23c7315330852",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca03::/64",
+            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-0d561f75bfe0565b1",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "712023778557",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "test-stack-private-us-west-2b"
+            },
+            "tags_all": {
+              "Name": "test-stack-private-us-west-2b"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-03e38b08477729e56",
+            "assign_ipv6_address_on_creation": true,
+            "availability_zone": "us-west-2a",
+            "availability_zone_id": "usw2-az2",
+            "cidr_block": "10.0.64.0/19",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": true,
+            "id": "subnet-03e38b08477729e56",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca00::/64",
+            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-0e4c03e1637f7da3a",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "712023778557",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "test-stack-public-us-west-2a"
+            },
+            "tags_all": {
+              "Name": "test-stack-public-us-west-2a"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:subnet/subnet-01f4f3ae425a408e5",
+            "assign_ipv6_address_on_creation": true,
+            "availability_zone": "us-west-2b",
+            "availability_zone_id": "usw2-az1",
+            "cidr_block": "10.0.192.0/19",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": true,
+            "id": "subnet-01f4f3ae425a408e5",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca01::/64",
+            "ipv6_cidr_block_association_id": "subnet-cidr-assoc-0b58242851cade8a4",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "712023778557",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "test-stack-public-us-west-2b"
+            },
+            "tags_all": {
+              "Name": "test-stack-public-us-west-2b"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "redshift",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:vpc/vpc-08a6cfe215aa111d2",
+            "assign_generated_ipv6_cidr_block": true,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-03e9a45c813025712",
+            "default_route_table_id": "rtb-0dca290699431a6a1",
+            "default_security_group_id": "sg-0c866a5d608a24b01",
+            "dhcp_options_id": "dopt-0715c47f",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-08a6cfe215aa111d2",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "vpc-cidr-assoc-04bc0ae96d481afd0",
+            "ipv6_cidr_block": "2600:1f14:34ee:ca00::/56",
+            "ipv6_cidr_block_network_border_group": "us-west-2",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-0dca290699431a6a1",
+            "owner_id": "712023778557",
+            "tags": {
+              "Name": "test-stack"
+            },
+            "tags_all": {
+              "Name": "test-stack"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "create_before_destroy": true
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_vpc_block_public_access_exclusion",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_vpc_dhcp_options",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_vpc_ipv4_cidr_block_association",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_vpn_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc",
+      "mode": "managed",
+      "type": "aws_vpn_gateway_attachment",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc_endpoints",
+      "mode": "data",
+      "type": "aws_vpc_endpoint_service",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": "s3",
+          "schema_version": 0,
+          "attributes": {
+            "acceptance_required": false,
+            "arn": "arn:aws:ec2:us-west-2:712023778557:vpc-endpoint-service/vpce-svc-0001be97e1865c74e",
+            "availability_zones": [
+              "us-west-2a",
+              "us-west-2b",
+              "us-west-2c",
+              "us-west-2d"
+            ],
+            "base_endpoint_dns_names": [
+              "s3.us-west-2.amazonaws.com"
+            ],
+            "filter": [
+              {
+                "name": "service-type",
+                "values": [
+                  "Gateway"
+                ]
+              }
+            ],
+            "id": "526544209",
+            "manages_vpc_endpoints": false,
+            "owner": "amazon",
+            "private_dns_name": "",
+            "private_dns_names": [],
+            "region": "us-west-2",
+            "service": "s3",
+            "service_id": "vpce-svc-0001be97e1865c74e",
+            "service_name": "com.amazonaws.us-west-2.s3",
+            "service_regions": null,
+            "service_type": "Gateway",
+            "supported_ip_address_types": [
+              "ipv4"
+            ],
+            "tags": {},
+            "timeouts": null,
+            "vpc_endpoint_policy_supported": true
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc_endpoints",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": []
+    },
+    {
+      "module": "module.test_stack.module.vpc.module.vpc_endpoints",
+      "mode": "managed",
+      "type": "aws_vpc_endpoint",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": "s3",
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-west-2:712023778557:vpc-endpoint/vpce-032ad2a0b386b56ba",
+            "auto_accept": null,
+            "cidr_blocks": [
+              "3.5.76.0/22",
+              "3.5.80.0/21",
+              "18.34.48.0/20",
+              "18.34.244.0/22",
+              "52.92.128.0/17",
+              "52.218.128.0/17"
+            ],
+            "dns_entry": [],
+            "dns_options": [],
+            "id": "vpce-032ad2a0b386b56ba",
+            "ip_address_type": "",
+            "network_interface_ids": [],
+            "owner_id": "712023778557",
+            "policy": "{\"Statement\":[{\"Action\":\"*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"*\"}],\"Version\":\"2008-10-17\"}",
+            "prefix_list_id": "pl-68a54001",
+            "private_dns_enabled": false,
+            "requester_managed": false,
+            "resource_configuration_arn": "",
+            "route_table_ids": [
+              "rtb-05cb3223c3341fe67",
+              "rtb-06fe5396cbb825c57",
+              "rtb-0df3d3d3244e79288"
+            ],
+            "security_group_ids": [],
+            "service_name": "com.amazonaws.us-west-2.s3",
+            "service_network_arn": "",
+            "service_region": "",
+            "state": "available",
+            "subnet_configuration": [],
+            "subnet_ids": [],
+            "tags": {
+              "Name": "s3"
+            },
+            "tags_all": {
+              "Name": "s3"
+            },
+            "timeouts": {
+              "create": "10m",
+              "delete": "10m",
+              "update": "10m"
+            },
+            "vpc_endpoint_type": "Gateway",
+            "vpc_id": "vpc-08a6cfe215aa111d2"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.test_stack.module.vpc.data.aws_availability_zones.available",
+            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this",
+            "module.test_stack.module.vpc.module.api_gateway_security_group.aws_security_group.this_name_prefix",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.private",
+            "module.test_stack.module.vpc.module.vpc.aws_route_table.public",
+            "module.test_stack.module.vpc.module.vpc.aws_subnet.private",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc.this",
+            "module.test_stack.module.vpc.module.vpc.aws_vpc_ipv4_cidr_block_association.this",
+            "module.test_stack.module.vpc.module.vpc_endpoints.aws_security_group.this",
+            "module.test_stack.module.vpc.module.vpc_endpoints.data.aws_vpc_endpoint_service.this"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,3 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Test template"
+Resources: {}

--- a/tests/test_tags.tf
+++ b/tests/test_tags.tf
@@ -13,6 +13,7 @@ provider "aws" {
   region = "us-west-2"  # or your preferred region
 }
 
+# Use minimal test configuration to avoid long-running resource creation
 module "test_stack" {
   source = "../modules/quilt"
   
@@ -21,10 +22,25 @@ module "test_stack" {
   internal = false
   create_new_vpc = true
   template_file = "${path.module}/test.yml"
+
+  # Minimize resource sizes
+  db_instance_class = "db.t3.micro"
+  db_multi_az = false
+  
+  search_instance_count = 1
+  search_instance_type = "t3.small.elasticsearch"
+  search_dedicated_master_enabled = false
+  search_zone_awareness_enabled = false
+  search_volume_size = 10
   
   parameters = {
     AdminEmail = "test@example.com"
   }
+
+  # Add shorter timeouts
+  create_timeout = "20m"
+  update_timeout = "20m"
+  delete_timeout = "20m"
 }
 
 locals {

--- a/tests/test_tags.tf
+++ b/tests/test_tags.tf
@@ -63,8 +63,11 @@ locals {
 
 output "test_common_tags" {
   value = local.test_tags.test_common_tags
+  description = "Test result for common tags"
 }
 
 output "test_stack_dependent_tags" {
   value = local.test_tags.test_stack_dependent_tags
+  description = "Test result for stack dependent tags"
+  sensitive = false
 }

--- a/tests/test_tags.tf
+++ b/tests/test_tags.tf
@@ -23,9 +23,10 @@ module "test_stack" {
   create_new_vpc = true
   template_file = "${path.module}/test.yml"
 
-  # Minimize resource sizes
+  # Minimize resource sizes and enable cleanup
   db_instance_class = "db.t3.micro"
   db_multi_az = false
+  db_deletion_protection = false
   
   search_instance_count = 1
   search_instance_type = "t3.small.elasticsearch"

--- a/tests/test_tags.tf
+++ b/tests/test_tags.tf
@@ -1,0 +1,53 @@
+terraform {
+  required_version = ">= 1.5.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"  # or your preferred region
+}
+
+module "test_stack" {
+  source = "../modules/quilt"
+  
+  name = "test-stack"
+  cidr = "10.0.0.0/16"
+  internal = false
+  create_new_vpc = true
+  template_file = "${path.module}/test.yml"
+  
+  parameters = {
+    AdminEmail = "test@example.com"
+  }
+}
+
+locals {
+  test_tags = {
+    test_common_tags = (
+      module.test_stack.common_tags == {
+        "quilt:stack-name" = "test-stack"
+      }
+    )
+    
+    test_stack_dependent_tags = (
+      module.test_stack.stack_dependent_tags == {
+        "quilt:stack-name" = "test-stack"
+        "quilt:stack-id"   = module.test_stack.stack_id
+      }
+    )
+  }
+}
+
+output "test_common_tags" {
+  value = local.test_tags.test_common_tags
+}
+
+output "test_stack_dependent_tags" {
+  value = local.test_tags.test_stack_dependent_tags
+}

--- a/tests/test_tags.tf
+++ b/tests/test_tags.tf
@@ -23,6 +23,9 @@ module "test_stack" {
   create_new_vpc = true
   template_file = "${path.module}/test.yml"
 
+  # Enable force destroy for testing
+  on_failure = "DELETE"
+
   # Minimize resource sizes and enable cleanup
   db_instance_class = "db.t3.micro"
   db_multi_az = false


### PR DESCRIPTION
## Description

Companion to https://github.com/quiltdata/deployment/pull/2042
Match id and stack name for Terraform-created resources

* Added common_tags and stack_dependent_tags in /modules/quilt/locals.tf to standardize tag structure
* Added comprehensive tag testing framework in /tests directory to verify tag behavior

## TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] [CHANGELOG](../tree/main/CHANGELOG.md) entry
- [ ] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*
