### PR TITLE
Upgrade ES to 7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+This version requires Quilt stack version 1.66 or later.
+
+- [Changed] Elasticsearch updated to 7.10 ([#89](https://github.com/quiltdata/iac/pull/89))
+
 ## [1.4.0] - 2025-12-18
 
 - [Changed] Update Postgres to 15.15 ([#94](https://github.com/quiltdata/iac/pull/94))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Optional release notice.
 
 This version requires Quilt stack version 1.66 or later.
 
-- [Changed] Elasticsearch updated to 7.10 ([#89](https://github.com/quiltdata/iac/pull/89))
+- [Changed] Update Elasticsearch to 7.10 ([#89](https://github.com/quiltdata/iac/pull/89))
 
 ## [1.4.0] - 2025-12-18
 

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -30,7 +30,7 @@ module "search_security_group" {
 
 resource "aws_elasticsearch_domain" "search" {
   domain_name           = var.domain_name
-  elasticsearch_version = "6.8"
+  elasticsearch_version = "7.10"
 
   cluster_config {
     instance_count           = var.instance_count


### PR DESCRIPTION
## Description

## TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry
- [x] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR upgrades Elasticsearch from version 6.8 to 7.10 in the search module infrastructure. The change is minimal, updating only the `elasticsearch_version` parameter in the Terraform configuration.

**Key Changes:**
- Updated `elasticsearch_version` from `"6.8"` to `"7.10"` in `modules/search/main.tf:33`
- Added CHANGELOG entry indicating this version requires Quilt stack version 1.66 or later
- The upgrade follows a similar pattern to the previous 6.8 upgrade (from an earlier version) done in PR #71

**Important Notes:**
- The CHANGELOG specifies a dependency on "Quilt stack version 1.66 or later", but the PR description doesn't provide details about what changes in stack 1.66 enable this ES version
- Elasticsearch 7.10 is the last version in the 7.x line before the transition to OpenSearch/Elasticsearch 8.x
- AWS supports in-place upgrades from ES 6.8 to 7.10, so this should be a smooth upgrade path
- The existing security configurations (TLS 1.2, node-to-node encryption, encryption at rest) remain unchanged and compatible with ES 7.10

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk - it's a straightforward version bump with proper changelog documentation
- Score reflects the simplicity and clarity of the change (single version string update), but reduced by 1 point due to: (1) the stack version 1.66 dependency mentioned in CHANGELOG lacks context about why this specific version is required, and (2) no explicit upgrade testing or rollback plan is documented in the PR
- No files require special attention - both changes are straightforward updates

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added ES 7.10 upgrade entry with stack version requirement |
| modules/search/main.tf | Updated elasticsearch_version from 6.8 to 7.10 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Operator
    participant TF as Terraform
    participant AWS as AWS Provider
    participant ES as Elasticsearch Domain
    participant Quilt as Quilt Stack (≥1.66)
    
    User->>TF: Apply updated configuration
    TF->>TF: Detect version change (6.8 → 7.10)
    TF->>AWS: Update aws_elasticsearch_domain
    AWS->>ES: Initiate version upgrade
    Note over ES: Blue/green deployment<br/>Maintains availability
    ES->>ES: Create new 7.10 domain
    ES->>ES: Migrate data from 6.8
    ES->>ES: Switch traffic to 7.10
    ES->>ES: Remove old 6.8 domain
    ES-->>AWS: Upgrade complete
    AWS-->>TF: Domain updated
    TF-->>User: Apply successful
    User->>Quilt: Verify stack compatibility (1.66+)
    Quilt-->>User: Services operational
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->