### PR TITLE
add upgrading note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+Upgrading to this version is only possible from version 1.1.0 or later.
+
 This version requires Quilt stack version 1.66 or later.
 
 - [Changed] Update Elasticsearch to 7.10 ([#89](https://github.com/quiltdata/iac/pull/89))


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Adds upgrade constraint documentation to the Unreleased section specifying that upgrading requires version 1.1.0 or later. This constraint exists because Elasticsearch 7.10 cannot be directly upgraded from versions before 6.8, which was introduced in version 1.1.0.

### Confidence Score: 5/5

- Safe to merge - documentation-only change with accurate upgrade constraint
- This is a straightforward documentation change that adds an important upgrade constraint to the CHANGELOG. The note is accurate (version 1.1.0 introduced ES 6.8, which is required before upgrading to ES 7.10), well-placed in the Unreleased section, and follows the existing format. No code changes, no functional impact, and the information is helpful for users upgrading their infrastructure.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Adds upgrading constraint note for Elasticsearch 7.10 migration path |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CL as CHANGELOG.md
    Dev->>CL: "Add upgrade constraint note"
    Note over CL: Specifies minimum version 1.1.0<br/>for upgrading to Unreleased
```