### PR TITLE
Suggest two-step upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Optional release notice.
 Upgrading to this version is only possible from version 1.1.0 or later.
 
 This version requires Quilt stack version 1.66 or later.
+Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading this module to avoid downtime.
 
 - [Changed] Update Elasticsearch to 7.10 ([#89](https://github.com/quiltdata/iac/pull/89))
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR enhances the upgrade notes in the CHANGELOG for the upcoming Elasticsearch 7.10 upgrade by adding an explicit instruction about the proper upgrade sequence.

**Change Details:**
- Adds a new line emphasizing that users must upgrade their Quilt stack to version 1.66 or later **before** upgrading this Terraform module
- Uses italics (*before*) to emphasize the critical ordering requirement
- Clarifies that following this sequence will "avoid downtime"

**Context:**
The unreleased version upgrades Elasticsearch from 6.8 to 7.10 (PR #89), which represents a major version change. This requires compatibility with Quilt stack version 1.66+. A previous commit (PR #97) added the base requirement, and this PR adds the critical timing/ordering instruction to prevent service disruption.

**Assessment:**
The change improves user experience by making the upgrade process clearer and more explicit. The warning about downtime provides important context for why the ordering matters, helping users understand this isn't just a recommendation but a critical requirement.

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk - it's a documentation-only change that improves clarity
- Score of 5 reflects: (1) Documentation-only change with no code modifications, (2) Improves user safety by clarifying upgrade sequence, (3) Consistent with changelog format and style, (4) Addresses a real operational concern about upgrade ordering, (5) No potential for introducing bugs or breaking changes
- No files require special attention - the single documentation change is straightforward and beneficial

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Adds clarifying note about upgrade order to prevent downtime during Elasticsearch 7.10 upgrade |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User/Operator
    participant Quilt as Quilt Stack
    participant TF as Terraform Module (IAC)
    participant ES as Elasticsearch

    Note over User,ES: Upgrade Sequence (Preventing Downtime)
    
    User->>Quilt: 1. Upgrade Quilt Stack to v1.66+
    activate Quilt
    Quilt-->>User: Stack upgraded successfully
    deactivate Quilt
    
    Note over User,ES: Wait for stack upgrade to complete
    
    User->>TF: 2. Update Terraform ref to latest
    activate TF
    TF->>TF: Update CHANGELOG references
    TF->>ES: 3. Initiate ES upgrade (6.8 → 7.10)
    activate ES
    ES-->>ES: Blue/green deployment
    ES-->>TF: Upgrade complete
    deactivate ES
    TF-->>User: Terraform apply successful
    deactivate TF
    
    Note over User,ES: ✓ No downtime (correct order)
    
    rect rgb(255, 200, 200)
        Note over User,ES: ⚠️ INCORRECT ORDER (causes downtime)
        User->>TF: X. Upgrade module BEFORE stack
        TF->>ES: Try ES 7.10 upgrade
        ES-->>Quilt: Incompatible with old stack
        Note over Quilt,ES: Service disruption/downtime
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->