### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.5.0] - 2026-01-13
+
 Upgrading to this version is only possible from version 1.1.0 or later.
 
 This version requires Quilt stack version 1.66 or later.
@@ -75,7 +77,8 @@ Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading 
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))
 
-[Unreleased]: https://github.com/quiltdata/iac/compare/1.4.0...HEAD
+[Unreleased]: https://github.com/quiltdata/iac/compare/1.5.0...HEAD
+[1.5.0]: https://github.com/quiltdata/iac/releases/tag/1.5.0
 [1.4.0]: https://github.com/quiltdata/iac/releases/tag/1.4.0
 [1.3.0]: https://github.com/quiltdata/iac/releases/tag/1.3.0
 [1.2.0]: https://github.com/quiltdata/iac/releases/tag/1.2.0


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR finalizes release 1.5.0 by moving the Elasticsearch 7.10 upgrade documentation from the Unreleased section to a proper versioned release. The changes are purely documentation updates that formalize the release structure.

**Changes made:**
- Added `[1.5.0]` release section with date 2026-01-13
- Moved existing upgrade notes (version 1.1.0 requirement, Quilt stack 1.66 requirement, upgrade ordering) under the new release section
- Updated the `[Unreleased]` comparison link from `1.4.0...HEAD` to `1.5.0...HEAD`
- Added version link reference for `[1.5.0]` pointing to the release tag

**Release accuracy:**
All content in the 1.5.0 section accurately reflects the actual infrastructure changes merged in previous PRs (ES version update in PR #89, upgrade notes in PRs #97 and #98). The version increment from 1.4.0 to 1.5.0 follows semantic versioning appropriately for a minor release containing a major dependency upgrade.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a standard release preparation with correct changelog formatting
- Score of 5 reflects: (1) Documentation-only change with zero code modifications, (2) Follows Keep a Changelog conventions correctly, (3) All version references and links are properly updated, (4) Release content accurately reflects merged changes, (5) Version numbering follows semantic versioning, (6) No potential for bugs or breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Properly formatted release 1.5.0 with correct version header, date, upgrade notes, changelog entry, and updated version links |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR89 as PR #89 (ES Upgrade)
    participant PR97 as PR #97 (Upgrade Note)
    participant PR98 as PR #98 (Two-Step Guide)
    participant Main as Main Branch
    participant Changelog as CHANGELOG.md
    participant PR99 as PR #99 (Release)
    participant Tag as Git Tag v1.5.0

    Note over Dev,Tag: Build up changes in Unreleased section
    
    Dev->>PR89: Upgrade Elasticsearch 6.8 → 7.10
    PR89->>Main: Merge (commit 7d2c60d)
    Note over Main,Changelog: ES upgrade in [Unreleased]
    
    Dev->>PR97: Add version 1.1.0 requirement
    PR97->>Main: Merge (commit 0b66695)
    Note over Main,Changelog: Upgrade constraint added
    
    Dev->>PR98: Add stack upgrade ordering note
    PR98->>Main: Merge (commit c20095b)
    Note over Main,Changelog: Two-step upgrade guidance added
    
    Note over Dev,Tag: Finalize release
    
    Dev->>PR99: Create Release 1.5.0
    PR99->>Changelog: Add [1.5.0] header with date
    PR99->>Changelog: Move content from [Unreleased]
    PR99->>Changelog: Update version link references
    PR99->>Main: Merge (commit 19b4f24)
    Main->>Tag: Create v1.5.0 tag
    
    Note over Tag: Release 1.5.0 published<br/>with ES 7.10 upgrade
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->