### PR TITLE
Add comprehensive tags support to infrastructure resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .terraform
 tfplan
+/.deploy
+/deploy
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+- [Added] Comprehensive tags support for all infrastructure resources ([#100](https://github.com/quiltdata/iac/pull/100))
+  - RDS database instances and security groups
+  - VPC, subnets, NAT gateways, and VPC endpoints
+  - ElasticSearch domain
+  - S3 bucket for CloudFormation templates
+  - Security groups (DB accessor, DB, user ingress)
+
 ## [1.5.0] - 2026-01-13
 
 Upgrading to this version is only possible from version 1.1.0 or later.

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -11,6 +11,8 @@ module "db_accessor_security_group" {
       source_security_group_id = module.db_security_group.security_group_id
     }
   ]
+
+  tags = var.tags
 }
 
 module "db_security_group" {
@@ -26,6 +28,8 @@ module "db_security_group" {
       source_security_group_id = module.db_accessor_security_group.security_group_id
     }
   ]
+
+  tags = var.tags
 }
 
 module "db" {
@@ -62,4 +66,6 @@ module "db" {
 
   backup_retention_period = 7
   deletion_protection     = var.deletion_protection
+
+  tags = var.tags
 }

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -41,3 +41,9 @@ variable "deletion_protection" {
   type     = bool
   nullable = false
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to RDS instance and security groups"
+}

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -22,6 +22,8 @@ module "vpc" {
   existing_public_subnets      = var.public_subnets
   existing_user_security_group = var.user_security_group
   existing_user_subnets        = var.user_subnets
+
+  tags = var.tags
 }
 
 module "db" {
@@ -38,6 +40,8 @@ module "db" {
   instance_class      = var.db_instance_class
   multi_az            = var.db_multi_az
   deletion_protection = var.db_deletion_protection
+
+  tags = var.tags
 }
 
 module "search" {
@@ -72,6 +76,8 @@ resource "aws_s3_bucket" "cft_bucket" {
 
   # Nothing valuable in this bucket, so make the cleanup easier.
   force_destroy = true
+
+  tags = var.tags
 }
 
 resource "aws_s3_bucket_versioning" "cft_bucket_versioning" {

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -59,6 +59,8 @@ module "search" {
   volume_type              = var.search_volume_type
   volume_iops              = var.search_volume_iops
   volume_throughput        = var.search_volume_throughput
+
+  tags = var.tags
 }
 
 resource "random_password" "admin_password" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -223,3 +223,9 @@ variable "on_failure" {
   type        = string
   default     = "ROLLBACK"
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to resources (DB, ElasticSearch domain, etc.)"
+}

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -66,4 +66,6 @@ resource "aws_elasticsearch_domain" "search" {
     subnet_ids         = var.zone_awareness_enabled ? var.subnet_ids : slice(var.subnet_ids, 0, 1)
     security_group_ids = [module.search_security_group.security_group_id]
   }
+
+  tags = var.tags
 }

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -71,3 +71,9 @@ variable "volume_type" {
   type     = string
   nullable = false
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to the ElasticSearch domain"
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -72,6 +72,8 @@ module "vpc" {
   enable_dns_support     = true
   enable_nat_gateway     = true
   one_nat_gateway_per_az = true
+
+  tags = var.tags
 }
 
 // Module name no longer accurate (see description); changing name causes tf apply to fail
@@ -86,6 +88,8 @@ module "api_gateway_security_group" {
 
   ingress_cidr_blocks = ["0.0.0.0/0"]
   ingress_rules       = ["https-443-tcp", "http-80-tcp"]
+
+  tags = var.tags
 }
 
 module "vpc_endpoints" {
@@ -109,4 +113,6 @@ module "vpc_endpoints" {
       create              = var.internal
     },
   }
+
+  tags = var.tags
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -68,3 +68,9 @@ variable "existing_user_subnets" {
     error_message = "Must contain 2 string ids or be null."
   }
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to VPC, subnets, and security groups"
+}


### PR DESCRIPTION
This PR adds comprehensive tags support to all major infrastructure resources in the IAC modules.

## Changes

### Modules Updated

1. **Search Module** (ElasticSearch)
   - Add tags variable
   - Apply tags to `aws_elasticsearch_domain` resource

2. **DB Module** (RDS)
   - Add tags variable
   - Apply tags to RDS instance
   - Apply tags to DB security group
   - Apply tags to DB accessor security group

3. **VPC Module**
   - Add tags variable
   - Apply tags to VPC and all subnets (public, private, intra)
   - Apply tags to NAT gateways
   - Apply tags to user ingress security group
   - Apply tags to VPC endpoints (S3 Gateway, API Gateway)

4. **Quilt Module**
   - Add tags variable
   - Apply tags to S3 bucket (CloudFormation templates)
   - Pass tags to all sub-modules (search, db, vpc)

## Resources Tagged

With these changes, the following AWS resources can be tagged:
- ✅ ElasticSearch domain
- ✅ RDS database instance
- ✅ VPC and subnets (public, private, intra)
- ✅ NAT gateways
- ✅ Security groups (DB, DB accessor, user ingress)
- ✅ VPC endpoints (S3 Gateway, API Gateway)
- ✅ S3 bucket (CloudFormation templates)

## Benefits

- Better resource tracking across stack deployments
- Improved cost allocation and billing analysis
- Easier resource management and identification
- Support for organizational tagging policies

## Example Usage

```hcl
module "quilt" {
  source = "github.com/quiltdata/iac//modules/quilt?ref=stack/tags"
  
  name = "my-stack"
  # ... other parameters ...
  
  tags = {
    StackId     = "my-stack"
    Environment = "production"
    ManagedBy   = "terraform"
    CostCenter  = "engineering"
  }
}
```

All tags are optional and default to an empty map if not provided.