### PR TITLE
docs(sso): note that auth params are Terraform/multi_sso format only

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -320,6 +320,13 @@ module "quilt" {
 
 ## Authentication Examples
 
+> **Note:** These examples use the Terraform IAC module, which supports per-provider parameters
+> (`GoogleAuth`, `AzureAuth`, etc.) and multiple simultaneous providers. If your stack was deployed
+> via the CloudFormation Console or AWS Marketplace, see the
+> [SSO configuration in the technical reference](https://docs.quiltdata.com/technical-reference#enabling-sso)
+> — those deployments use `SingleSignOnProvider`, `SingleSignOnClientId`, `SingleSignOnClientSecret`,
+> and `SingleSignOnBaseUrl` instead.
+
 ### Google OAuth Integration
 
 ```hcl

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -320,12 +320,12 @@ module "quilt" {
 
 ## Authentication Examples
 
-> **Note:** These examples use the Terraform IAC module, which supports per-provider parameters
-> (`GoogleAuth`, `AzureAuth`, etc.) and multiple simultaneous providers. If your stack was deployed
-> via the CloudFormation Console or AWS Marketplace, see the
+> **Note:** These examples use per-provider parameters (`GoogleAuth`, `AzureAuth`, etc.), which
+> apply to stacks built with `multi_sso: true`. If your stack has a `SingleSignOnProvider` dropdown
+> in its CloudFormation parameters, it was built with `multi_sso: false` and uses a different set of
+> parameters — see the
 > [SSO configuration in the technical reference](https://docs.quiltdata.com/technical-reference#enabling-sso)
-> — those deployments use `SingleSignOnProvider`, `SingleSignOnClientId`, `SingleSignOnClientSecret`,
-> and `SingleSignOnBaseUrl` instead.
+> instead. The deployment method (Terraform, Console, CLI) does not determine which format applies.
 
 ### Google OAuth Integration
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -77,9 +77,11 @@ The `parameters` map configures the Quilt application. Here are all available pa
 
 ### Authentication Parameters
 
-> **Note:** These parameters apply to Terraform IAC module deployments (`multi_sso: true`).
-> CloudFormation Console and AWS Marketplace deployments use a different set:
+> **Note:** These parameters apply to stacks built with `multi_sso: true` (per-provider format).
+> Stacks built with `multi_sso: false` use a different set:
 > `SingleSignOnProvider`, `SingleSignOnClientId`, `SingleSignOnClientSecret`, and `SingleSignOnBaseUrl`.
+> To determine which format your stack uses, check your stack's CloudFormation parameters for a
+> `SingleSignOnProvider` dropdown — if present, use those parameters instead.
 > See the [SSO configuration in the technical reference](https://docs.quiltdata.com/technical-reference#enabling-sso).
 
 | Parameter | Description | Values | Default |

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -77,6 +77,11 @@ The `parameters` map configures the Quilt application. Here are all available pa
 
 ### Authentication Parameters
 
+> **Note:** These parameters apply to Terraform IAC module deployments (`multi_sso: true`).
+> CloudFormation Console and AWS Marketplace deployments use a different set:
+> `SingleSignOnProvider`, `SingleSignOnClientId`, `SingleSignOnClientSecret`, and `SingleSignOnBaseUrl`.
+> See the [SSO configuration in the technical reference](https://docs.quiltdata.com/technical-reference#enabling-sso).
+
 | Parameter | Description | Values | Default |
 |-----------|-------------|--------|---------|
 | `PasswordAuth` | Enable username/password authentication | `"Enabled"`, `"Disabled"` | `"Enabled"` |


### PR DESCRIPTION
## Summary

- Adds a clarifying note to `EXAMPLES.md` Authentication Examples section explaining these use the Terraform IAC module (`multi_sso: true`) format
- Adds a clarifying note to `VARIABLES.md` Authentication Parameters section with the same context
- Both notes cross-link to the technical reference for CloudFormation Console / Marketplace users who use a different parameter set (`SingleSignOnProvider` dropdown)

## Background

Two SSO deployment formats exist:
- **CFT Console / Marketplace** (50+ customer deployments): `SingleSignOnProvider` dropdown + shared `SingleSignOnClientId/Secret/BaseUrl`
- **Terraform IAC module** (`multi_sso: true`): per-provider params documented here

Companion PR: quiltdata/quilt#4771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR primarily adds clarifying notes to `EXAMPLES.md` and `VARIABLES.md` explaining that the authentication parameters (`GoogleAuth`, `AzureAuth`, etc.) are specific to Terraform IAC module deployments (`multi_sso: true`) and cross-links to the technical reference for CloudFormation Console/Marketplace users. It also bundles the **1.6.0 release**, which changes the default Elasticsearch instance types from Intel `m5` to Graviton2 `m6g` across all documentation and the live Terraform module defaults.

Key changes:
- **New SSO clarifying notes** added to the Authentication Examples section in `EXAMPLES.md` and the Authentication Parameters section in `VARIABLES.md`, correctly distinguishing Terraform vs. CFT Console parameter formats.
- **Default instance type change** (`modules/quilt/variables.tf`): `search_instance_type` changed from `m5.xlarge.elasticsearch` → `m6g.xlarge.elasticsearch` and `search_dedicated_master_type` from `m5.large.elasticsearch` → `m6g.large.elasticsearch`. This is a potentially impactful change for existing users who rely on module defaults and upgrade without pinning their instance type.
- **Inconsistent migration**: `m5.12xlarge.elasticsearch` in the "Extreme Scale" / "XXX-Large" / "XXXX-Large" examples in `EXAMPLES.md` (line 313) and `README.md` (lines 868, 880) were **not** updated to `m6g`, unlike all other instance sizes.
- **CHANGELOG link references**: The new `[1.6.0]` entry is missing its link definition at the bottom of `CHANGELOG.md`, and the `[Unreleased]` comparison link still targets `1.5.0...HEAD` instead of `1.6.0...HEAD`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation consistency fixes recommended.
- The SSO documentation notes are accurate and helpful. The Terraform default change is intentional and changelog-documented. The two issues found (missed m5.12xlarge → m6g migration and missing CHANGELOG link references) are purely documentation/cosmetic and do not affect runtime behavior or infrastructure correctness.
- CHANGELOG.md (missing `[1.6.0]` link reference and stale `[Unreleased]` link), EXAMPLES.md and README.md (leftover `m5.12xlarge.elasticsearch` references not migrated to `m6g`).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| modules/quilt/variables.tf | Updates default `search_instance_type` from `m5.xlarge.elasticsearch` to `m6g.xlarge.elasticsearch` and `search_dedicated_master_type` from `m5.large.elasticsearch` to `m6g.large.elasticsearch`. Clean and correct change. |
| CHANGELOG.md | Adds a new `[1.6.0]` entry for the Graviton2 default instance type change, but missing the `[1.6.0]` link reference at the bottom of the file and the `[Unreleased]` link still points to `1.5.0...HEAD` instead of `1.6.0...HEAD`. |
| EXAMPLES.md | Updates m5 → m6g instance types throughout, adds the SSO clarifying note, but misses updating the `m5.12xlarge.elasticsearch` in the "Extreme Scale" example at line 313. |
| README.md | Updates m5 → m6g instance type documentation throughout minimum/production requirements sections, but misses updating `m5.12xlarge.elasticsearch` in the "XXX-Large" and "XXXX-Large" sizing examples at lines 868 and 880. |
| VARIABLES.md | Updates default instance type documentation from m5 to m6g, and adds the SSO clarifying note to the Authentication Parameters section. No issues found. |
| examples/main.tf | Updates m5 → m6g instance types in commented/active configuration examples, along with minor trailing whitespace cleanup. Clean change. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Quilt Deployment] --> B{Deployment Method?}

    B --> C[CloudFormation Console\nor AWS Marketplace]
    B --> D[Terraform IAC Module]

    C --> E[SSO Parameters\nSingleSignOnProvider\nSingleSignOnClientId\nSingleSignOnClientSecret\nSingleSignOnBaseUrl]

    D --> F[SSO Parameters\nmulti_sso: true\nGoogleAuth / GoogleClientId / GoogleClientSecret\nOktaAuth / OktaBaseUrl / OktaClientId / OktaClientSecret\nAzureAuth / AzureClientId / AzureClientSecret\nOneLoginAuth / OneLoginBaseUrl / ...]

    E --> G[Single provider\nshared params]
    F --> H[Multiple simultaneous\nproviders supported]

    D --> I[Default ES Instance Types\nv1.6.0 Change]
    I --> J[Data Nodes: m6g.xlarge.elasticsearch\nMaster Nodes: m6g.large.elasticsearch\nGraviton2 - better price/perf]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `EXAMPLES.md`, line 313 ([link](https://github.com/quiltdata/iac/blob/fa113a0321d36b5066241d6c676f594b86259832/EXAMPLES.md#L313)) 

   **Missed m5 → m6g migration for extreme-scale example**

   All other instance types in this file were updated from `m5` to `m6g`, but this "Extreme Scale" example at line 313 still references `m5.12xlarge.elasticsearch`. The same oversight exists in `README.md` at lines 868 and 880 (the "XXX-Large" and "XXXX-Large" sections). For documentation consistency, these should be updated to `m6g.12xlarge.elasticsearch` if that instance size is available in the target regions.


2. `CHANGELOG.md`, line 84-85 ([link](https://github.com/quiltdata/iac/blob/fa113a0321d36b5066241d6c676f594b86259832/CHANGELOG.md#L84-L85)) 

   **Missing `[1.6.0]` link reference and stale `[Unreleased]` link**

   The `[1.6.0]` section header was added but its comparison link is missing at the bottom of the file (the link definitions section). Additionally, the `[Unreleased]` link still compares against `1.5.0...HEAD` rather than `1.6.0...HEAD`. Both will render as non-clickable text in rendered Markdown.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: fa113a0</sub>

<!-- /greptile_comment -->