### PR TITLE
Add enable_lf_grants for opt-in LF TableWildcard grants

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -53,6 +53,12 @@ This document provides comprehensive documentation for all variables available i
 | `search_volume_throughput` | `number` | `null` | EBS throughput (MiB/s, for some gp3 volumes) | 125-1000 |
 | `search_auto_tune_desired_state` | `string` | `"DISABLED"` | ElasticSearch Auto-Tune state | `"ENABLED"`, `"DISABLED"` |
 
+### Lake Formation Variables
+
+| Variable            | Type   | Default | Description                                                                                                                                                                                                                               |
+|---------------------|--------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `enable_lf_grants`  | `bool` | `false` | Enable per-role Lake Formation TableWildcard grants. Requires the CloudFormation execution role to be a Lake Formation administrator. Leave `false` unless LF enforcement is active and the deploying role is on the LF admin list.       |
+
 ### CloudFormation Stack Variables
 
 | Variable | Type | Default | Description |

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -101,6 +101,8 @@ resource "aws_cloudformation_stack" "stack" {
   parameters = merge(
     var.parameters,
     {
+      EnableLakeFormationGrants = var.enable_lf_grants ? "Enabled" : "Disabled"
+
       VPC               = module.vpc.vpc_id
       Subnets           = join(",", module.vpc.private_subnets)
       PublicSubnets     = var.internal ? null : join(",", module.vpc.public_subnets)

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -101,7 +101,7 @@ resource "aws_cloudformation_stack" "stack" {
   parameters = merge(
     var.parameters,
     {
-      EnableLakeFormationGrants = var.enable_lf_grants ? "Enabled" : "Disabled"
+      EnableLakeFormationGrants = var.enable_lf_grants ? "Enabled" : null
 
       VPC               = module.vpc.vpc_id
       Subnets           = join(",", module.vpc.private_subnets)

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -138,6 +138,13 @@ variable "search_volume_type" {
   description = "Type of EBS volumes attached to data nodes in the ElasticSearch cluster"
 }
 
+variable "enable_lf_grants" {
+  type        = bool
+  nullable    = false
+  default     = false
+  description = "Enable per-role Lake Formation TableWildcard grants. Requires the CloudFormation execution role to be a Lake Formation administrator. Leave false unless LF enforcement is active and the deploying role is on the LF admin list."
+}
+
 variable "template_file" {
   type        = string
   nullable    = true


### PR DESCRIPTION
## Summary
- Adds `enable_lf_grants` variable (bool, default `false`) to the `modules/quilt` module
- Maps to `EnableLakeFormationGrants` CFT parameter (`Enabled`/`Disabled`)
- Documents the variable in VARIABLES.md

## Context
Per-role Lake Formation TableWildcard grants require the CloudFormation execution
role to be a Lake Formation administrator. Without this gate, deploys fail with
`AccessDeniedException` on any account where the deploying role isn't on the LF
admin list — which includes all new installs and accounts without LF enforcement.

This makes the grants opt-in so operators must explicitly enable them after
completing the LF admin bootstrap (adding the deploying role to the LF admin list).

## Companion changes needed
- **deployment repo**: Add `EnableLakeFormationGrants` CFT parameter and
  `LakeFormationGrantsEnabled` condition to gate `_DYNAMIC_DB_ROLE_GRANTS`
  in `lakeformation.py`

## Test plan
- [ ] `terraform fmt -check` passes
- [ ] `terraform validate` passes
- [ ] Existing deployments unaffected (default `false` → parameter omitted or `Disabled`)
- [ ] Verify CFT accepts `EnableLakeFormationGrants` parameter after deployment-side changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `enable_lf_grants` boolean variable (default `false`) to the `modules/quilt` module, wiring it to the `EnableLakeFormationGrants` CloudFormation parameter so that per-role Lake Formation TableWildcard grants are opt-in rather than always-on.

- `EnableLakeFormationGrants` is unconditionally sent as `\"Disabled\"` when the feature is off, instead of `null`. Passing an unrecognized parameter to CloudFormation raises an error, so any `terraform apply` on a deployment whose CFT template hasn't yet received the companion parameter change will fail immediately.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — will break existing deployments if applied before the companion CFT change.

One P1 finding: the parameter is always sent as "Disabled" rather than null, creating a hard dependency on the companion CFT template change being deployed first. A one-line fix (null instead of "Disabled") aligns with the existing null pattern in the file and makes the rollout order-independent.

modules/quilt/main.tf — line 104 where EnableLakeFormationGrants is unconditionally set.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/quilt/main.tf | Adds EnableLakeFormationGrants to the CFT parameters block, but always passes "Disabled" (not null) when disabled — will break existing deployments whose templates don't yet have this parameter. |
| modules/quilt/variables.tf | Adds well-formed enable_lf_grants bool variable with nullable=false, default=false, and a clear description. |
| VARIABLES.md | Adds a new "Lake Formation Variables" section documenting enable_lf_grants with type, default, and usage notes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[terraform apply] --> B{enable_lf_grants?}
    B -- true --> C["EnableLakeFormationGrants = 'Enabled'"]
    B -- false --> D["EnableLakeFormationGrants = 'Disabled'\n⚠️ always sent"]
    C --> E[merge with var.parameters]
    D --> E
    E --> F[aws_cloudformation_stack]
    F --> G{CFT template has\nEnableLakeFormationGrants\nparameter?}
    G -- yes --> H[Stack update succeeds]
    G -- no --> I[❌ CloudFormation rejects\nunknown parameter]
```

<sub>Reviews (1): Last reviewed commit: ["Add enable\_lf\_grants variable for opt-in..."](https://github.com/quiltdata/iac/commit/ae652a550a5a8620657e153f1ddf4424a82e36c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28114922)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->