### PR TITLE
Allow terraform destroy without a template file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
-- [Changed] Allow `terraform destroy` to run without providing `template_file`: pass `null` to skip the `aws_s3_object.cft` resource. Apply still requires a real path (enforced by precondition). ([#105](https://github.com/quiltdata/iac/pull/105))
+- [Added] `template_file` may now be set to `null` for `terraform destroy`; apply still requires a real path. ([#105](https://github.com/quiltdata/iac/pull/105))
 
 ## [1.6.0] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+- [Changed] Allow `terraform destroy` to run without providing `template_file`: pass `null` to skip the `aws_s3_object.cft` resource. Apply still requires a real path (enforced by precondition). ([#105](https://github.com/quiltdata/iac/pull/105))
+
 ## [1.6.0] - 2026-02-24
 
 If you rely on the default `search_instance_type` / `search_dedicated_master_type`:

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -9,7 +9,7 @@ This document provides comprehensive documentation for all variables available i
 | Variable | Type | Description | Validation |
 |----------|------|-------------|------------|
 | `name` | `string` | Name for VPC, DB, CloudFormation stack, and resource prefix | ≤20 chars, lowercase alphanumeric + hyphens |
-| `template_file` | `string` | Path to local CloudFormation template file | Must be a valid file path |
+| `template_file` | `string` | Path to local CloudFormation template file (pass `null` only with `terraform destroy`) | Required for `plan`/`apply`; pass `null` with `terraform destroy` |
 | `parameters` | `map(any)` | CloudFormation stack parameters | See [CloudFormation Parameters](#cloudformation-parameters) |
 | `internal` | `bool` | Create internal ALB (true) or internet-facing ALB (false) | - |
 

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -142,7 +142,7 @@ resource "aws_cloudformation_stack" "stack" {
     ]
     precondition {
       condition     = var.template_file != null
-      error_message = "template_file is required for apply. Pass null only with terraform destroy."
+      error_message = "template_file is required for plan/apply. Pass null only with terraform destroy."
     }
   }
 }

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -80,6 +80,7 @@ resource "aws_s3_bucket_versioning" "cft_bucket_versioning" {
 }
 
 resource "aws_s3_object" "cft" {
+  count  = var.template_file != null ? 1 : 0
   bucket = aws_s3_bucket.cft_bucket.id
   key    = local.template_key
   source = var.template_file
@@ -139,5 +140,9 @@ resource "aws_cloudformation_stack" "stack" {
     ignore_changes = [
       on_failure,
     ]
+    precondition {
+      condition     = var.template_file != null
+      error_message = "template_file is required for apply. Pass null only with terraform destroy."
+    }
   }
 }

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -142,7 +142,7 @@ variable "template_file" {
   type        = string
   nullable    = true
   default     = null
-  description = "Local file to upload to S3 to use as the CloudFormation template"
+  description = "Local file to upload to S3 to use as the CloudFormation template. Pass null only with terraform destroy; apply requires a real path."
 }
 
 variable "parameters" {


### PR DESCRIPTION
## Description

Allow `terraform destroy` to run without providing a template file.

### Module changes

`modules/quilt/main.tf`:
- Add `count = var.template_file != null ? 1 : 0` to `aws_s3_object.cft`. With `count = 0`, terraform skips evaluating the resource block — so `filemd5(var.template_file)` no longer fires when null is passed.
- Add `precondition` to `aws_cloudformation_stack.stack`'s `lifecycle` block requiring `template_file != null`. This guards the apply path: passing null on apply errors at plan time.

`modules/quilt/variables.tf`:
- Update `template_file` description to document the contract.

### Why the precondition is safe

Since Terraform 1.3.4 ([hashicorp/terraform#32051](https://github.com/hashicorp/terraform/pull/32051)), preconditions on resources being destroyed are skipped during full destroy. So `terraform destroy` with `template_file = null` proceeds; only `apply` is gated.

### Migration impact

For existing deployments, the address change `aws_s3_object.cft` → `aws_s3_object.cft[0]` is handled automatically by terraform's count-refactoring detection ([refactoring docs](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring): "When you add `count` to an existing resource that didn't previously have the argument, Terraform automatically proposes moving the original object to instance `0`"). Plan shows `# (moved from module.quilt.aws_s3_object.cft)` and an in-place update — no destroy/create churn. **No operator action needed** — terraform handles the address change automatically on first apply. Verified empirically against an existing dev workspace.

### Caller pattern

```hcl
# Apply
module "quilt" {
  template_file = local.build_file
  ...
}

# Destroy
module "quilt" {
  template_file = null
  ...
}
```
