### PR TITLE
docs: use S3 native state locking instead of DynamoDB

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -55,10 +55,9 @@ provider "aws" {
 
 terraform {
   backend "s3" {
-    bucket       = "YOUR-TERRAFORM-STATE-BUCKET"
-    key          = "quilt/dev/terraform.tfstate"
-    region       = "YOUR-AWS-REGION"
-    use_lockfile = true
+    bucket = "YOUR-TERRAFORM-STATE-BUCKET"
+    key    = "quilt/dev/terraform.tfstate"
+    region = "YOUR-AWS-REGION"
   }
 }
 
@@ -844,7 +843,6 @@ terraform {
     workspace_key_prefix = "quilt"
     key                  = "terraform.tfstate"
     region               = "YOUR-AWS-REGION"
-    use_lockfile         = true
   }
 }
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -55,9 +55,10 @@ provider "aws" {
 
 terraform {
   backend "s3" {
-    bucket = "YOUR-TERRAFORM-STATE-BUCKET"
-    key    = "quilt/dev/terraform.tfstate"
-    region = "YOUR-AWS-REGION"
+    bucket       = "YOUR-TERRAFORM-STATE-BUCKET"
+    key          = "quilt/dev/terraform.tfstate"
+    region       = "YOUR-AWS-REGION"
+    use_lockfile = true
   }
 }
 
@@ -843,6 +844,7 @@ terraform {
     workspace_key_prefix = "quilt"
     key                  = "terraform.tfstate"
     region               = "YOUR-AWS-REGION"
+    use_lockfile         = true
   }
 }
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -149,7 +149,7 @@ terraform {
     key            = "quilt/prod/terraform.tfstate"
     region         = "YOUR-AWS-REGION"
     encrypt        = true
-    dynamodb_table = "terraform-locks"
+    use_lockfile   = true
   }
 }
 
@@ -644,7 +644,7 @@ terraform {
     key            = "quilt/prod/terraform.tfstate"
     region         = "YOUR-AWS-REGION"
     encrypt        = true
-    dynamodb_table = "terraform-locks"
+    use_lockfile   = true
   }
 }
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -42,7 +42,7 @@ This document provides comprehensive operational procedures for cloud teams mana
 
 **Team Requirements**
 
-- [ ] Terraform >= 1.5.0 installed
+- [ ] Terraform >= 1.10.0 installed
 - [ ] AWS CLI configured
 - [ ] Git repository for configuration
 - [ ] Access to monitoring systems

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ aws ce get-cost-and-usage \
 > **📖 Additional Documentation**: For comprehensive enterprise installation guidance, refer to the official documentation at [docs.quilt.bio](https://docs.quilt.bio). This Terraform module complements the standard installation process with Infrastructure as Code automation.
 
 ### Required Tools
-- **[Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)** >= 1.5.0
+- **[Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)** >= 1.10.0
 - **AWS CLI** >= 2.0 configured with appropriate permissions
 - **Git** for version control and configuration management
 - **jq** (optional) for JSON processing in automation scripts
@@ -708,9 +708,10 @@ provider "aws" {
 
 terraform {
   backend "s3" {
-    bucket = "YOUR-TERRAFORM-STATE-BUCKET"
-    key    = "quilt/terraform.tfstate"
-    region = "YOUR-AWS-REGION"
+    bucket       = "YOUR-TERRAFORM-STATE-BUCKET"
+    key          = "quilt/terraform.tfstate"
+    region       = "YOUR-AWS-REGION"
+    use_lockfile = true
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ This section provides step-by-step instructions specifically for cloud teams to 
 brew install terraform
 
 # Linux
-wget https://releases.hashicorp.com/terraform/1.6.0/terraform_1.6.0_linux_amd64.zip
-unzip terraform_1.6.0_linux_amd64.zip
+wget https://releases.hashicorp.com/terraform/1.14.9/terraform_1.14.9_linux_amd64.zip
+unzip terraform_1.14.9_linux_amd64.zip
 sudo mv terraform /usr/local/bin/
 
 # Verify installation
-terraform --version  # Should show >= 1.5.0
+terraform --version  # Should show >= 1.10.0
 ```
 
 **Step 1.2: Configure AWS CLI**

--- a/README.md
+++ b/README.md
@@ -708,10 +708,9 @@ provider "aws" {
 
 terraform {
   backend "s3" {
-    bucket       = "YOUR-TERRAFORM-STATE-BUCKET"
-    key          = "quilt/terraform.tfstate"
-    region       = "YOUR-AWS-REGION"
-    use_lockfile = true
+    bucket = "YOUR-TERRAFORM-STATE-BUCKET"
+    key    = "quilt/terraform.tfstate"
+    region = "YOUR-AWS-REGION"
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,6 @@ aws s3 mb s3://YOUR-COMPANY-terraform-state --region YOUR-AWS-REGION
 aws s3api put-bucket-versioning \
   --bucket YOUR-COMPANY-terraform-state \
   --versioning-configuration Status=Enabled
-
-# Optional: Create DynamoDB table for state locking
-aws dynamodb create-table \
-  --table-name terraform-locks \
-  --attribute-definitions AttributeName=LockID,AttributeType=S \
-  --key-schema AttributeName=LockID,KeyType=HASH \
-  --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
-  --region YOUR-AWS-REGION
 ```
 
 #### 2. SSL Certificate Setup (10 minutes)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -38,11 +38,10 @@ terraform {
     key            = "quilt/terraform.tfstate"
     region         = "YOUR-AWS-REGION"
     encrypt        = true
-    # Optional: DynamoDB table for state locking
-    # dynamodb_table = "terraform-locks"
+    use_lockfile   = true
   }
-  
-  required_version = ">= 1.5.0"
+
+  required_version = ">= 1.10.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Description

Switch example Terraform backend configs and onboarding instructions from DynamoDB-based state locking to S3 native locking (`use_lockfile = true`, Terraform 1.10+). HashiCorp deprecated `dynamodb_table` in favor of `use_lockfile`, which stores lock metadata as a `.tflock` object in the same state bucket — no separate table required.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates all example Terraform backend configurations and onboarding documentation from DynamoDB-based state locking (`dynamodb_table`) to S3 native locking (`use_lockfile = true`, requiring Terraform 1.10+), and updates all version references accordingly. The previously flagged stale `>= 1.5.0` constraints in `README.md` are correctly resolved in this change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all version references are consistent and the migration is a straightforward documentation-only change.

Only a single P2 finding (missing `required_version` guard in EXAMPLES.md snippets). All previously flagged P1 stale-version issues are resolved. No logic, security, or runtime concerns.

EXAMPLES.md — backend snippets lack `required_version` guard to match the 1.10+ requirement enforced by `examples/main.tf`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| EXAMPLES.md | Replaces `dynamodb_table` with `use_lockfile = true` in two backend snippets; neither snippet includes a `required_version` guard to match the 1.10+ requirement. |
| OPERATIONS.md | Updates team requirements checklist from `>= 1.5.0` to `>= 1.10.0`; straightforward and correct. |
| README.md | Updates Terraform install example to 1.14.9, version comment to `>= 1.10.0`, removes DynamoDB table creation commands, and updates Prerequisites to `>= 1.10.0`; all previously flagged stale-version issues are resolved. |
| examples/main.tf | Replaces commented-out `dynamodb_table` with `use_lockfile = true` and bumps `required_version` to `>= 1.10.0`; consistent and correct. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant TF as Terraform CLI (>=1.10)
    participant S3 as S3 Bucket

    Dev->>TF: terraform init / apply
    TF->>S3: GET state object (terraform.tfstate)
    TF->>S3: PUT lock object (.tflock)
    Note over S3: Lock stored as .tflock<br/>alongside state — no DynamoDB needed
    TF->>S3: PUT state object (updated)
    TF->>S3: DELETE lock object (.tflock)
    TF-->>Dev: Apply complete
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `README.md`, line 41 ([link](https://github.com/quiltdata/iac/blob/3102c6584532798d003e57e75d90b051c5180382/README.md#L41)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale minimum Terraform version — breaks `use_lockfile`**

   `use_lockfile` was introduced in Terraform 1.10 and will produce an error on any earlier release. This comment still tells users `>= 1.5.0` is sufficient, which contradicts the `required_version = ">= 1.10.0"` added in `examples/main.tf`. A user following these instructions with Terraform 1.5–1.9 will hit an unsupported-argument error when initialising the S3 backend.

   

   The same stale constraint also appears on line 510 in the **Prerequisites** section.

2. `README.md`, line 510 ([link](https://github.com/quiltdata/iac/blob/3102c6584532798d003e57e75d90b051c5180382/README.md#L510)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Prerequisites section still lists `>= 1.5.0`**

   Same staleness as line 41 — this prerequisites list now conflicts with the `use_lockfile` requirement (Terraform 1.10+). Users who install 1.5–1.9 based on this page will get a backend initialisation error.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Restrict use\_lockfile additions to snipp..."](https://github.com/quiltdata/iac/commit/2c0aa35596b66aca4bd993073d5148675f724900) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29983272)</sub>

<!-- /greptile_comment -->