### PR TITLE
Update Postgres to 15.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Optional release notice.
 ## [Unreleased] - YYYY-MM-DD
 
 - [Added] `template_file` may now be set to `null` for `terraform destroy`; apply still requires a real path. ([#105](https://github.com/quiltdata/iac/pull/105))
+- [Changed] Update Postgres to 15.18 ([#108](https://github.com/quiltdata/iac/pull/108))
 
 ## [1.6.0] - 2026-02-24
 

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -39,7 +39,7 @@ module "db" {
   engine                      = "postgres"
   allow_major_version_upgrade = true
   auto_minor_version_upgrade  = false
-  engine_version              = "15.15"
+  engine_version              = "15.18"
   storage_type                = "gp2"
   allocated_storage           = 100
   storage_encrypted           = true


### PR DESCRIPTION
## Description

Bump RDS `engine_version` from `15.15` to `15.18`, the latest available Postgres 15.x minor in RDS.

The recent PostgreSQL security release (15.18, 16.14, 17.10, etc.) prompted a customer (via IT) to ask that we move to the most recent minor of whichever major version we run. We're on 15.x, so the target is 15.18 — this is a minor-version patch, not the 16.x major upgrade (which can wait).

Note: `apply_immediately = true`, so this minor-version bump applies in place and causes a brief instance restart the moment `terraform apply` runs — it is *not* deferred to the RDS maintenance window. Control timing by choosing when to run the apply.

## TODO

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry
- [x] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the RDS PostgreSQL `engine_version` from `15.15` to `15.18` in response to a recent PostgreSQL security release, accompanied by the corresponding CHANGELOG entry.

- **`modules/db/main.tf`**: Single-line change updating `engine_version` to `\"15.18\"`; all other RDS settings (`apply_immediately = true`, `auto_minor_version_upgrade = false`, backup, deletion protection, etc.) remain unchanged.
- **`CHANGELOG.md`**: Adds a `[Changed]` entry under `[Unreleased]` for this upgrade.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a one-line minor-version bump with no schema, config, or behavioral changes beyond the PostgreSQL engine version itself.

The change is minimal and well-scoped: a single RDS engine_version string update from 15.15 to 15.18. Both are within the PostgreSQL 15 minor-version series, so no compatibility concerns apply. The apply_immediately = true behavior (pre-existing) is acknowledged in the PR description, so operators are informed about the immediate restart on apply.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/db/main.tf | Single-line engine_version bump from 15.15 to 15.18; all other RDS config unchanged. |
| CHANGELOG.md | Added [Changed] entry for the Postgres 15.18 upgrade under [Unreleased]. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Operator
    participant Terraform
    participant AWS RDS

    Operator->>Terraform: terraform apply
    Terraform->>AWS RDS: Update engine_version 15.15 → 15.18
    Note over AWS RDS: apply_immediately=true<br/>triggers immediate restart
    AWS RDS-->>Terraform: Instance restarting…
    AWS RDS-->>Terraform: Available (PostgreSQL 15.18)
    Terraform-->>Operator: Apply complete
```

<sub>Reviews (2): Last reviewed commit: ["Add CHANGELOG entry for Postgres 15.18"](https://github.com/quiltdata/iac/commit/e749cf1cfd71c033ab0d16a2c5b0e5c8aba77006) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34146898)</sub>

<!-- /greptile_comment -->