### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
-## [1.7.0] - 2026-05-27
+## [1.7.0] - 2026-05-28
 
 - [Added] `template_file` may now be set to `null` for `terraform destroy`; apply still requires a real path. ([#105](https://github.com/quiltdata/iac/pull/105))
 - [Changed] Update Postgres to 15.18 ([#108](https://github.com/quiltdata/iac/pull/108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.7.0] - 2026-05-27
+
 - [Added] `template_file` may now be set to `null` for `terraform destroy`; apply still requires a real path. ([#105](https://github.com/quiltdata/iac/pull/105))
 - [Changed] Update Postgres to 15.18 ([#108](https://github.com/quiltdata/iac/pull/108))
 
@@ -88,7 +90,8 @@ Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading 
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))
 
-[Unreleased]: https://github.com/quiltdata/iac/compare/1.6.0...HEAD
+[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.0...HEAD
+[1.7.0]: https://github.com/quiltdata/iac/releases/tag/1.7.0
 [1.6.0]: https://github.com/quiltdata/iac/releases/tag/1.6.0
 [1.5.0]: https://github.com/quiltdata/iac/releases/tag/1.5.0
 [1.4.0]: https://github.com/quiltdata/iac/releases/tag/1.4.0


### PR DESCRIPTION
Release 1.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `CHANGELOG.md` to cut the 1.7.0 release, moving the two pending entries (`template_file` null support and Postgres 15.18 upgrade) from the `[Unreleased]` section into a new dated `[1.7.0]` heading and updating the comparison URL accordingly.

- Adds `## [1.7.0] - 2026-05-27` section with the two previously unreleased entries.
- Updates the `[Unreleased]` diff link from `1.6.0...HEAD` to `1.7.0...HEAD` and adds the `[1.7.0]` tag link.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a documentation-only change with no executable code modified.

The only changed file is CHANGELOG.md. The new version section is correctly structured, the date matches, the two entries accurately reference their respective PRs, and both the comparison URL and tag link are consistent with the pattern used in every prior release.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Changelog updated for 1.7.0 release — new version heading added with correct date, comparison URL updated, and tag link appended; structure is consistent with prior releases. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["## [Unreleased] - YYYY-MM-DD\n(empty, ready for next changes)"] --> B["## [1.7.0] - 2026-05-27\n- template_file null support\n- Postgres 15.18"]
    B --> C["## [1.6.0] - 2026-02-24"]
    C --> D["## [1.5.0] - 2026-01-13"]
    D --> E["... older versions ..."]
    F["[Unreleased] link → 1.7.0...HEAD"] -.-> A
    G["[1.7.0] link → releases/tag/1.7.0"] -.-> B
```

<sub>Reviews (1): Last reviewed commit: ["Release 1.7.0"](https://github.com/quiltdata/iac/commit/2dd7d3c2366fae32a9a88d3d98998609e7d9b764) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34155519)</sub>

<!-- /greptile_comment -->