### PR TITLE
Pin security-group module to < 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+- [Fixed] Pin `security-group` module to `< 6.0.0`; upstream v6.0.0 dropped arguments these modules pass, breaking `terraform plan`/`apply` ([#110](https://github.com/quiltdata/iac/pull/110))
+
 ## [1.7.0] - 2026-05-28
 
 - [Added] `template_file` may now be set to `null` for `terraform destroy`; apply still requires a real path. ([#105](https://github.com/quiltdata/iac/pull/105))

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,5 +1,6 @@
 module "db_accessor_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.identifier}-db-accessor"
   description = "For resources that need access to DB"
@@ -14,7 +15,8 @@ module "db_accessor_security_group" {
 }
 
 module "db_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.identifier}-db"
   description = "For DB resources"

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -1,5 +1,6 @@
 module "search_accessor_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.domain_name}-search-accessor"
   description = "For resources that need access to search cluster"
@@ -14,7 +15,8 @@ module "search_accessor_security_group" {
 }
 
 module "search_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.domain_name}-search"
   description = "For search cluster resources"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -76,7 +76,8 @@ module "vpc" {
 
 // Module name no longer accurate (see description); changing name causes tf apply to fail
 module "api_gateway_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   create = local.new_network_valid
 


### PR DESCRIPTION
## Description

`terraform-aws-modules/security-group/aws` was sourced with **no version constraint** in `modules/db`, `modules/search`, and `modules/vpc` (5 module blocks). Its **v6.0.0**, published 2026-06-03, drops the `ingress_with_source_security_group_id` / `egress_with_source_security_group_id` arguments these modules pass.

As a result, an unconstrained `terraform init` now resolves `6.0.0` and **every stack on any current iac ref fails `terraform plan`**:

```
Error: Unsupported argument
  on .terraform/modules/quilt/modules/db/main.tf line 23, in module "db_security_group":
  23:   ingress_with_source_security_group_id = [
An argument named "ingress_with_source_security_group_id" is not expected here.
```

This pins all 5 usages to `< 6.0.0`, matching the `rds` module pin already present in `modules/db/main.tf`. A proper migration to the v6 interface can be done separately.

Discovered while deploying the glacier dev stack (quiltdata/deployment#2446) — the prior run at 12:04 UTC resolved security-group `5.3.1` and passed plan; the 14:30 UTC run resolved `6.0.0` and failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins all five usages of `terraform-aws-modules/security-group/aws` to `< 6.0.0` across `modules/db`, `modules/search`, and `modules/vpc`, preventing `terraform init` from resolving the newly-released v6.0.0 which dropped the `ingress_with_source_security_group_id` and `egress_with_source_security_group_id` arguments these modules depend on.

- All 5 module blocks that source `terraform-aws-modules/security-group/aws` are now constrained, covering the full blast radius of the breaking upgrade.
- The constraint format (`< 6.0.0`, no lower bound) is consistent with the existing `rds` module pin already present in `modules/db/main.tf`; no `.terraform.lock.hcl` is tracked in the repo, so no lock-file update is needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, minimal fix that restores terraform plan across all affected stacks with no functional behavior change.

Every usage of the breaking module is pinned, the constraint is consistent with the existing RDS pin pattern, and no lock file is tracked so no additional update is required. The change is purely additive (version constraints) and cannot introduce regressions.

No files require special attention. The terraform-aws-modules/vpc/aws module in modules/vpc/main.tf is intentionally unpinned and is a separate module unaffected by this issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/db/main.tf | Adds version = "< 6.0.0" to both db_accessor_security_group and db_security_group module blocks, matching the constraint already present on the rds module. |
| modules/search/main.tf | Adds version = "< 6.0.0" to both search_accessor_security_group and search_security_group module blocks, which rely on ingress/egress_with_source_security_group_id dropped in v6. |
| modules/vpc/main.tf | Adds version = "< 6.0.0" to api_gateway_security_group; the terraform-aws-modules/vpc/aws module (used by vpc and vpc_endpoints) retains no version constraint, but that is a different module and out of scope. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[terraform init] --> B{Resolve security-group module}
    B -->|Before PR: no constraint| C[Resolves latest → v6.0.0]
    B -->|After PR: version < 6.0.0| D[Resolves latest compatible → v5.x.x]
    C --> E["terraform plan FAILS\n(ingress/egress_with_source_security_group_id\nno longer supported)"]
    D --> F["terraform plan SUCCEEDS\n(all arguments compatible)"]

    subgraph Pinned modules
        G["modules/db\n· db_accessor_security_group\n· db_security_group"]
        H["modules/search\n· search_accessor_security_group\n· search_security_group"]
        I["modules/vpc\n· api_gateway_security_group"]
    end

    D --> G
    D --> H
    D --> I
```

<sub>Reviews (1): Last reviewed commit: ["Pin security-group module to &lt; 6.0.0"](https://github.com/quiltdata/iac/commit/6b7a1c6958bc620a05f1548bdedbc9eccbb6f9b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35387444)</sub>

<!-- /greptile_comment -->