### PR TITLE
Pin all registry modules with ~> (#111 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
-- [Fixed] Restore `terraform plan`/`apply` after the `security-group` module's v6.0.0 release dropped arguments these modules use ([#110](https://github.com/quiltdata/iac/pull/110))
-- [Fixed] Pin the previously unpinned `vpc` module and standardize all registry pins on `~>` (`security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0`), preventing a future major release from silently breaking plans ([#112](https://github.com/quiltdata/iac/pull/112))
+- [Fixed] Pin every registry module with `~>` so an upstream major can't silently break `terraform plan`/`apply` — resolves the `security-group` v6.0.0 break and constrains the rest (`security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0`) ([#110](https://github.com/quiltdata/iac/pull/110), [#112](https://github.com/quiltdata/iac/pull/112))
 
 ## [1.7.0] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Optional release notice.
 ## [Unreleased] - YYYY-MM-DD
 
 - [Fixed] Restore `terraform plan`/`apply` after the `security-group` module's v6.0.0 release dropped arguments these modules use ([#110](https://github.com/quiltdata/iac/pull/110))
-- [Changed] Constrain all registry modules with `~>` so a future major release can't silently break plans: `security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0` ([#112](https://github.com/quiltdata/iac/pull/112))
+- [Fixed] Pin the previously unpinned `vpc` module and standardize all registry pins on `~>` (`security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0`), preventing a future major release from silently breaking plans ([#112](https://github.com/quiltdata/iac/pull/112))
 
 ## [1.7.0] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
-- [Fixed] Pin `security-group` module to `< 6.0.0`; upstream v6.0.0 dropped arguments these modules pass, breaking `terraform plan`/`apply` ([#110](https://github.com/quiltdata/iac/pull/110))
+- [Fixed] Restore `terraform plan`/`apply` after the `security-group` module's v6.0.0 release dropped arguments these modules use ([#110](https://github.com/quiltdata/iac/pull/110))
+- [Changed] Constrain all registry modules with `~>` so a future major release can't silently break plans: `security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0` ([#112](https://github.com/quiltdata/iac/pull/112))
 
 ## [1.7.0] - 2026-05-28
 

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,6 +1,6 @@
 module "db_accessor_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "< 6.0.0"
+  version = "~> 5.0"
 
   name        = "${var.identifier}-db-accessor"
   description = "For resources that need access to DB"
@@ -16,7 +16,7 @@ module "db_accessor_security_group" {
 
 module "db_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "< 6.0.0"
+  version = "~> 5.0"
 
   name        = "${var.identifier}-db"
   description = "For DB resources"
@@ -32,7 +32,7 @@ module "db_security_group" {
 
 module "db" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "< 6.0.0"
+  version = "~> 5.0"
 
   identifier = var.identifier
 

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,5 +1,6 @@
 module "db_accessor_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.identifier}-db-accessor"
   description = "For resources that need access to DB"
@@ -14,7 +15,8 @@ module "db_accessor_security_group" {
 }
 
 module "db_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.identifier}-db"
   description = "For DB resources"

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -1,5 +1,6 @@
 module "search_accessor_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.domain_name}-search-accessor"
   description = "For resources that need access to search cluster"
@@ -14,7 +15,8 @@ module "search_accessor_security_group" {
 }
 
 module "search_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   name        = "${var.domain_name}-search"
   description = "For search cluster resources"

--- a/modules/search/main.tf
+++ b/modules/search/main.tf
@@ -1,6 +1,6 @@
 module "search_accessor_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "< 6.0.0"
+  version = "~> 5.0"
 
   name        = "${var.domain_name}-search-accessor"
   description = "For resources that need access to search cluster"
@@ -16,7 +16,7 @@ module "search_accessor_security_group" {
 
 module "search_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "< 6.0.0"
+  version = "~> 5.0"
 
   name        = "${var.domain_name}-search"
   description = "For search cluster resources"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -78,7 +78,7 @@ module "vpc" {
 // Module name no longer accurate (see description); changing name causes tf apply to fail
 module "api_gateway_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "< 6.0.0"
+  version = "~> 5.0"
 
   create = local.new_network_valid
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -76,7 +76,8 @@ module "vpc" {
 
 // Module name no longer accurate (see description); changing name causes tf apply to fail
 module "api_gateway_security_group" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "< 6.0.0"
 
   create = local.new_network_valid
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -37,7 +37,7 @@ locals {
 }
 
 module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
+  source = "terraform-aws-modules/vpc/aws"
   version = "~> 6.0"
 
   create_vpc = local.new_network_valid
@@ -91,7 +91,7 @@ module "api_gateway_security_group" {
 }
 
 module "vpc_endpoints" {
-  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "~> 6.0"
 
   create = local.new_network_valid

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -37,7 +37,8 @@ locals {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
 
   create_vpc = local.new_network_valid
 
@@ -90,7 +91,8 @@ module "api_gateway_security_group" {
 }
 
 module "vpc_endpoints" {
-  source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 6.0"
 
   create = local.new_network_valid
 


### PR DESCRIPTION
Follow-up from #111: audit `modules/` for unpinned registry modules and standardize the pinning style.

## Changes

- **Pin the two remaining unpinned modules** — `terraform-aws-modules/vpc/aws` (`module "vpc"` and the `vpc-endpoints` submodule) to `~> 6.0`, their current working major (deployed: 6.6.1).
- **Standardize every registry pin on `~>`** — convert `security-group` (×5) and `rds` (×1) from `< 6.0.0` to `~> 5.0`. Same resolution as before (security-group 5.x, rds 5.x); this is operator style plus an explicit lower bound.

After this, every registry module under `modules/` carries a `~>` constraint that blocks the next major while allowing minor/patch updates — the failure mode `security-group` v6.0.0 hit (fixed in #110).

## Why `~>`

The pessimistic operator is HashiCorp's documented recommendation for module pinning, bounds both ends, and is more idiomatic than a bare `< X.0.0`. Module pins are local to each call, so this can't conflict with a consumer's own pins; the only cross-boundary effect is the AWS provider floor, which is unchanged (already 6.x via vpc).

## Verification

`terraform init -upgrade` resolves vpc → 6.6.1, security-group → 5.3.1, rds → 5.9.x (unchanged from before this PR).

Formatting (the `source`-line alignment and a pre-existing `variables.tf`) is intentionally left out and handled in a separate `terraform fmt` PR.
