### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.7.1] - 2026-06-04
+
 - [Fixed] Pin every registry module with `~>` so an upstream major can't silently break `terraform plan`/`apply` — resolves the `security-group` v6.0.0 break and constrains the rest (`security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0`) ([#110](https://github.com/quiltdata/iac/pull/110), [#112](https://github.com/quiltdata/iac/pull/112))
 
 ## [1.7.0] - 2026-05-28
@@ -92,7 +94,8 @@ Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading 
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))
 
-[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.0...HEAD
+[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.1...HEAD
+[1.7.1]: https://github.com/quiltdata/iac/releases/tag/1.7.1
 [1.7.0]: https://github.com/quiltdata/iac/releases/tag/1.7.0
 [1.6.0]: https://github.com/quiltdata/iac/releases/tag/1.6.0
 [1.5.0]: https://github.com/quiltdata/iac/releases/tag/1.5.0


### PR DESCRIPTION
## Description

Stamps the changelog for the 1.7.1 release. The sole change in 1.7.1 is the registry-module pinning fix (#110 + #112): pin every registry module with `~>` so an upstream major can't silently break `terraform plan`/`apply`.

Release date is set to 2026-06-04, but should be confirmed against the actual merge date before tagging (the 1.7.0 release PR included a "Set release date to merge date" step).

## TODO

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stamps the CHANGELOG for the 1.7.1 patch release, which pins every Terraform registry module using `~>` to prevent silent breakage from upstream major version bumps.

- Adds a `[1.7.1] - 2026-06-04` section with the single changelog entry describing the registry-module pinning fix (referencing #110 and #112), moves it out of `[Unreleased]`, and leaves the `[Unreleased]` section empty.
- Updates the `[Unreleased]` comparison link from `1.7.0...HEAD` to `1.7.1...HEAD` and adds the corresponding `[1.7.1]` release tag link at the bottom of the file.

<h3>Confidence Score: 5/5</h3>

Changelog-only update; no executable code is touched and the format is consistent with all prior release entries.

The change is a single-file, documentation-only edit. The new section header, changelog entry, comparison link, and tag reference all follow the established pattern exactly. The release date (2026-06-04) matches today's date per the PR description note, and the PR description explicitly flags the confirm merge date before tagging step, showing awareness of the process.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds a new [1.7.1] dated section with the registry-module pinning fix entry, updates the [Unreleased] compare link, and appends the [1.7.1] tag reference — all consistent with the existing changelog format. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["[Unreleased] — empty"] -->|was| B["[Unreleased] contains 1.7.1 fix entry"]
    B -->|stamped as| C["[1.7.1] - 2026-06-04\n• Pin registry modules with ~>"]
    C --> D["[1.7.0] - 2026-05-28"]
    E["[Unreleased] link: 1.7.0...HEAD"] -->|updated to| F["[Unreleased] link: 1.7.1...HEAD"]
    G["(no [1.7.1] ref link)"] -->|added| H["[1.7.1]: releases/tag/1.7.1"]
```

<sub>Reviews (1): Last reviewed commit: ["Release 1.7.1"](https://github.com/quiltdata/iac/commit/4f892787b8d4c441430ed8e401c587121c1b3c00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35562223)</sub>

<!-- /greptile_comment -->