### PR TITLE
Add CI: terraform fmt + validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.5.0"
+          terraform_version: "1.10.0"
           terraform_wrapper: false
       - run: terraform fmt -check -recursive -diff
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.5.0"
+          terraform_version: "1.10.0"
           terraform_wrapper: false
       # -backend=false: validate needs init for provider/module schemas but no backend or cloud credentials.
       - run: terraform init -backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.15.5"
+          terraform_version: "1.5.0"
           terraform_wrapper: false
       - run: terraform fmt -check -recursive -diff
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.15.5"
+          terraform_version: "1.5.0"
           terraform_wrapper: false
       # -backend=false: validate needs init for provider/module schemas but no backend or cloud credentials.
       - run: terraform init -backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.10.0"
+          terraform_version: "1.5.0"
           terraform_wrapper: false
       - run: terraform fmt -check -recursive -diff
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: "1.10.0"
+          terraform_version: "1.5.0"
           terraform_wrapper: false
       # -backend=false: validate needs init for provider/module schemas but no backend or cloud credentials.
       - run: terraform init -backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,21 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
-    name: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
+          terraform_version: "1.15.5"
           terraform_wrapper: false
       - run: terraform fmt -check -recursive -diff
 
   validate:
-    name: validate
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -35,6 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: hashicorp/setup-terraform@v4
         with:
+          terraform_version: "1.15.5"
           terraform_wrapper: false
       # -backend=false: validate needs init for provider/module schemas but no backend or cloud credentials.
       - run: terraform init -backend=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+      - run: terraform fmt -check -recursive -diff
+
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir:
+          - modules/cnames
+          - modules/db
+          - modules/search
+          - modules/vpc
+          - modules/quilt
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+      # -backend=false: validate needs init for provider/module schemas but no backend or cloud credentials.
+      - run: terraform init -backend=false
+      - run: terraform validate -no-color

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -19,12 +19,12 @@ provider "aws" {
   # Replace with your AWS account ID
   allowed_account_ids = ["YOUR-ACCOUNT-ID"]
   # Replace with your preferred AWS region
-  region              = "YOUR-AWS-REGION"
-  
+  region = "YOUR-AWS-REGION"
+
   default_tags {
     tags = {
       Project     = "quilt"
-      Environment = "production"  # or "development", "staging"
+      Environment = "production" # or "development", "staging"
       Owner       = "data-team"
       CostCenter  = "engineering"
     }
@@ -34,11 +34,11 @@ provider "aws" {
 terraform {
   # Configure remote state storage (recommended for production)
   backend "s3" {
-    bucket         = "YOUR-TERRAFORM-STATE-BUCKET"
-    key            = "quilt/terraform.tfstate"
-    region         = "YOUR-AWS-REGION"
-    encrypt        = true
-    use_lockfile   = true
+    bucket       = "YOUR-TERRAFORM-STATE-BUCKET"
+    key          = "quilt/terraform.tfstate"
+    region       = "YOUR-AWS-REGION"
+    encrypt      = true
+    use_lockfile = true
   }
 
   required_version = ">= 1.10.0"
@@ -54,12 +54,12 @@ terraform {
 locals {
   # Stack name (≤20 chars, lowercase alphanumeric + hyphens)
   name = "quilt-prod"
-  
+
   # Path to your CloudFormation YAML template
   # Place a local copy of your CloudFormation YAML Template at build_file_path
   # and check it into git. Contact your account manager for the template.
   build_file_path = "./quilt-template.yml"
-  
+
   # Your Quilt catalog domain name
   quilt_web_host = "data.YOUR-COMPANY.com"
 }
@@ -89,35 +89,35 @@ module "quilt" {
   template_file = local.build_file_path
 
   # Network configuration
-  internal       = false  # Set to true for VPN-only access
-  create_new_vpc = true   # Set to false to use existing VPC
+  internal       = false # Set to true for VPN-only access
+  create_new_vpc = true  # Set to false to use existing VPC
   cidr           = "10.0.0.0/16"
 
   # Database configuration
-  db_instance_class      = "db.t3.small"    # Adjust based on needs
-  db_multi_az            = true             # High availability
-  db_deletion_protection = true             # Prevent accidental deletion
+  db_instance_class      = "db.t3.small" # Adjust based on needs
+  db_multi_az            = true          # High availability
+  db_deletion_protection = true          # Prevent accidental deletion
   # db_network_type = "IPV4"                # Uncomment for IPv4-only VPCs
   # db_snapshot_identifier = "snap-12345"   # Uncomment to restore from snapshot
 
   # ElasticSearch configuration
   # Choose a sizing configuration based on your data volume:
-  
+
   # Small (Development/Testing - <100GB data)
   # search_dedicated_master_enabled = false
   # search_zone_awareness_enabled   = false
   # search_instance_count          = 1
   # search_instance_type           = "m6g.large.elasticsearch"
   # search_volume_size             = 512
-  
+
   # Medium (Default Production - 100GB-1TB data)
   search_dedicated_master_enabled = true
   search_zone_awareness_enabled   = true
-  search_instance_count          = 2
-  search_instance_type           = "m6g.xlarge.elasticsearch"
-  search_volume_size             = 1024
-  search_volume_type             = "gp2"
-  
+  search_instance_count           = 2
+  search_instance_type            = "m6g.xlarge.elasticsearch"
+  search_volume_size              = 1024
+  search_volume_type              = "gp2"
+
   # Large (High Volume - 1TB-5TB data)
   # search_dedicated_master_enabled = true
   # search_zone_awareness_enabled   = true
@@ -125,7 +125,7 @@ module "quilt" {
   # search_instance_type           = "m6g.xlarge.elasticsearch"
   # search_volume_size             = 2048
   # search_volume_type             = "gp3"
-  
+
   # X-Large (Enterprise - 5TB-15TB data)
   # search_dedicated_master_enabled = true
   # search_zone_awareness_enabled   = true
@@ -155,40 +155,40 @@ module "quilt" {
     QuiltWebHost      = local.quilt_web_host
 
     # Authentication configuration
-    PasswordAuth = "Enabled"  # Always enable for initial setup
-    
+    PasswordAuth = "Enabled" # Always enable for initial setup
+
     # Google OAuth (optional)
-    GoogleAuth         = "Disabled"  # Change to "Enabled" to use Google OAuth
-    GoogleClientId     = ""          # Your Google OAuth client ID
+    GoogleAuth         = "Disabled" # Change to "Enabled" to use Google OAuth
+    GoogleClientId     = ""         # Your Google OAuth client ID
     GoogleClientSecret = var.google_client_secret
-    
+
     # Okta SAML/OAuth (optional)
-    OktaAuth         = "Disabled"    # Change to "Enabled" to use Okta
-    OktaBaseUrl      = ""            # https://YOUR-COMPANY.okta.com/oauth2/default
-    OktaClientId     = ""            # Your Okta client ID
+    OktaAuth         = "Disabled" # Change to "Enabled" to use Okta
+    OktaBaseUrl      = ""         # https://YOUR-COMPANY.okta.com/oauth2/default
+    OktaClientId     = ""         # Your Okta client ID
     OktaClientSecret = var.okta_client_secret
-    
+
     # OneLogin OAuth (optional)
-    OneLoginAuth         = "Disabled"  # Change to "Enabled" to use OneLogin
-    OneLoginBaseUrl      = ""          # https://YOUR-COMPANY.onelogin.com/oidc/2
-    OneLoginClientId     = ""          # Your OneLogin client ID
-    OneLoginClientSecret = ""          # Your OneLogin client secret
-    
+    OneLoginAuth         = "Disabled" # Change to "Enabled" to use OneLogin
+    OneLoginBaseUrl      = ""         # https://YOUR-COMPANY.onelogin.com/oidc/2
+    OneLoginClientId     = ""         # Your OneLogin client ID
+    OneLoginClientSecret = ""         # Your OneLogin client secret
+
     # Azure AD OAuth (optional)
-    AzureAuth         = "Disabled"     # Change to "Enabled" to use Azure AD
-    AzureBaseUrl      = ""             # https://login.microsoftonline.com/tenant-id/v2.0
-    AzureClientId     = ""             # Your Azure AD client ID
-    AzureClientSecret = ""             # Your Azure AD client secret
-    
+    AzureAuth         = "Disabled" # Change to "Enabled" to use Azure AD
+    AzureBaseUrl      = ""         # https://login.microsoftonline.com/tenant-id/v2.0
+    AzureClientId     = ""         # Your Azure AD client ID
+    AzureClientSecret = ""         # Your Azure AD client secret
+
     # SSO domain restriction (optional)
-    SingleSignOnDomains = ""           # Comma-separated list: "YOUR-COMPANY.com,subsidiary.com"
+    SingleSignOnDomains = "" # Comma-separated list: "YOUR-COMPANY.com,subsidiary.com"
 
     # Optional features
-    Qurator              = "Enabled"   # Enable Quilt's data quality features
-    ChunkedChecksums     = "Enabled"   # Enable chunked checksums for large files
-    CloudTrailBucket     = ""          # S3 bucket for CloudTrail logs
-    CanaryNotificationsEmail = ""      # Email for monitoring alerts
-    
+    Qurator                  = "Enabled" # Enable Quilt's data quality features
+    ChunkedChecksums         = "Enabled" # Enable chunked checksums for large files
+    CloudTrailBucket         = ""        # S3 bucket for CloudTrail logs
+    CanaryNotificationsEmail = ""        # Email for monitoring alerts
+
     # Advanced configuration (optional)
     # ManagedUserRoleExtraPolicies = "arn:aws:iam::YOUR-ACCOUNT-ID:policy/CustomPolicy"
     # S3BucketPolicyExcludeArnsFromDeny = "arn:aws:iam::YOUR-ACCOUNT-ID:user/service-account"
@@ -203,7 +203,7 @@ module "cnames" {
 
   lb_dns_name    = module.quilt.stack.outputs.LoadBalancerDNSName
   quilt_web_host = local.quilt_web_host
-  zone_id        = "YOUR-ROUTE53-ZONE-ID"  # Your Route53 hosted zone ID
+  zone_id        = "YOUR-ROUTE53-ZONE-ID" # Your Route53 hosted zone ID
 }
 
 # Outputs

--- a/modules/search/variables.tf
+++ b/modules/search/variables.tf
@@ -63,7 +63,7 @@ variable "volume_size" {
 }
 
 variable "volume_throughput" {
-  type = number
+  type        = number
   description = "EBS throughput (for some gp3 volumes)"
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -37,7 +37,7 @@ locals {
 }
 
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "~> 6.0"
 
   create_vpc = local.new_network_valid
@@ -91,7 +91,7 @@ module "api_gateway_security_group" {
 }
 
 module "vpc_endpoints" {
-  source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "~> 6.0"
 
   create = local.new_network_valid


### PR DESCRIPTION
## Description

Adds CI to the repo (there was none) plus the formatting cleanup it requires.

**Two credential-free jobs**, on PRs and pushes to `main`:
- **fmt** — `terraform fmt -check -recursive`.
- **validate** — per-module `terraform init -backend=false` + `terraform validate`, matrixed over `modules/{cnames,db,search,vpc,quilt}`. `validate` never contacts cloud APIs, and `init -backend=false` only fetches provider/module schemas over the network — no AWS credentials.

The first commit runs `terraform fmt` (whitespace only) so the new fmt gate passes; it picks up pre-existing drift in `examples/main.tf` and `modules/search/variables.tf`, plus the two `modules/vpc` `source` lines left unaligned in #112.

`examples/` is excluded from `validate` because it sources the module via a remote release ref, not local code. A security scan (Trivy) was considered and deferred to a follow-up — the current findings (mostly on the throwaway `cft_bucket` and ES audit logging) warrant their own triage.

## TODO

CHANGELOG entry and the dev-stack deploy promise are intentionally omitted: this is CI/tooling plus whitespace formatting, with no change to the module's behavior or interface.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bootstraps CI for the repository with two credential-free jobs (`fmt` and `validate`) that run on PRs and pushes to `main`. The remaining three files are pure `terraform fmt` whitespace normalization with no logic changes.

- **`fmt` job**: runs `terraform fmt -check -recursive -diff` from the repo root (covering all `.tf` files, including `examples/`).
- **`validate` job**: matrixed over five module directories; each slot runs `terraform init -backend=false` (provider schema fetch only, no AWS credentials) followed by `terraform validate`. Terraform is pinned at `1.5.0`, matching the floor in `modules/quilt/main.tf`, and `permissions: contents: read` provides least-privilege at the workflow level.
- **Formatting changes** in `examples/main.tf`, `modules/search/variables.tf`, and `modules/vpc/main.tf` are mechanical `terraform fmt` output (comment spacing, `=`-sign alignment).

<h3>Confidence Score: 5/5</h3>

Safe to merge — CI-only addition with no changes to module logic or interface.

All three non-workflow files are mechanical terraform fmt output (whitespace only). The workflow itself is correctly structured: Terraform pinned to 1.5.0 (matching the module's required_version), least-privilege contents: read permissions, fail-fast: false on the matrix, and terraform_wrapper: false to propagate exit codes cleanly. No production code, no state changes, no credentials involved.

.github/workflows/ci.yml is the only substantive change; the five-slot validate matrix downloads providers on every run without caching, but this is a convenience issue, not a correctness one.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | New CI workflow adding fmt + validate jobs; Terraform pinned at 1.5.0, least-privilege permissions set, no provider-download caching between matrix slots |
| examples/main.tf | Pure terraform fmt whitespace normalization — no logic changes |
| modules/search/variables.tf | Single-line alignment fix for volume_throughput variable — no logic changes |
| modules/vpc/main.tf | source = alignment fix for two module blocks — no logic changes |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    trigger["on: pull_request / push to main"]

    trigger --> fmt_job["**fmt** job\nubuntu-latest"]
    trigger --> validate_job["**validate** job\nubuntu-latest\nfail-fast: false"]

    fmt_job --> fmt_checkout["actions/checkout@v6"]
    fmt_checkout --> fmt_setup["setup-terraform@v4\nv1.5.0, wrapper=false"]
    fmt_setup --> fmt_run["terraform fmt -check -recursive -diff\n(repo root, includes examples/)"]

    validate_job --> matrix["matrix:\nmodules/cnames\nmodules/db\nmodules/search\nmodules/vpc\nmodules/quilt"]

    matrix --> v_checkout["actions/checkout@v6"]
    v_checkout --> v_setup["setup-terraform@v4\nv1.5.0, wrapper=false"]
    v_setup --> v_init["terraform init -backend=false\n(provider/module schemas only)"]
    v_init --> v_validate["terraform validate -no-color"]

    style fmt_run fill:#d4edda
    style v_validate fill:#d4edda
```

<sub>Reviews (2): Last reviewed commit: ["CI: pin Terraform to the module&#39;s minimu..."](https://github.com/quiltdata/iac/commit/bfeebff1e127a133a268e43dd758306d78cd49a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35566385)</sub>

<!-- /greptile_comment -->