### PR TITLE
Add Transit Gateway egress mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+- [Added] Transit Gateway egress mode for new VPCs: set `enable_transit_gateway = true` (+ `transit_gateway_id`) to route private-subnet egress through a Transit Gateway instead of NAT gateways; IPv6 egress is opt-in via `transit_gateway_ipv6_egress`. See [Transit Gateway egress](README.md#transit-gateway-egress) ([#115](https://github.com/quiltdata/iac/pull/115))
+
 ## [1.7.2] - 2026-06-08
 
 - [Fixed] Bump `modules/cnames` AWS provider constraint from `~> 5.0` to `~> 6.0` so it resolves alongside the `vpc` module's `aws >= 6.28` requirement — using `quilt` + `cnames` in one root previously failed `terraform init` ([#117](https://github.com/quiltdata/iac/pull/117))

--- a/README.md
+++ b/README.md
@@ -823,7 +823,12 @@ delay.
 **Reversibility:** removing `enable_transit_gateway` (or setting it `false`)
 restores the NAT gateways and IPv6 egress-only IGW. Toggling it on or off for an
 already-deployed VPC recreates/destroys NAT gateways and their Elastic IPs and
-briefly interrupts egress, so do it in a maintenance window.
+briefly interrupts egress, so do it in a maintenance window. Either direction
+also **changes the stack's public egress IP** — disabling releases the NAT
+Elastic IPs (AWS won't hand the same ones back), and enabling sends egress out
+through the TGW's NAT instead — so anything that allowlists Quilt's egress
+address (a license endpoint, a partner firewall, a SaaS IP allowlist) must be
+updated, or it breaks silently.
 
 ### Profile
 You may wish to set a specific AWS profile before executing `terraform`

--- a/README.md
+++ b/README.md
@@ -771,6 +771,56 @@ resource "aws_vpc_endpoint" "api_gateway_endpoint" {
 }
 ```
 
+### Transit Gateway egress
+
+By default a new Quilt VPC reaches the internet through Quilt-created NAT
+gateways. If you operate a Transit Gateway (TGW) as your egress boundary, set
+`enable_transit_gateway = true` (only with `create_new_vpc = true`). Quilt still
+creates the VPC, subnets, and endpoints, but instead disables the NAT gateways
+and the IPv6 egress-only IGW, attaches the VPC to your TGW (in the intra
+subnets), and points each private route table's default route at the TGW. The
+S3 gateway endpoint is unchanged, so bulk S3 traffic stays on the endpoint and
+does **not** traverse the TGW — only genuinely external egress does.
+
+```hcl
+module "quilt" {
+  # ...
+  create_new_vpc         = true
+  enable_transit_gateway = true
+  transit_gateway_id     = "tgw-0123456789abcdef0" # an existing TGW, or one created in this same config
+  # transit_gateway_ipv6_egress = true             # only if your TGW carries IPv6 egress
+}
+```
+
+`transit_gateway_id` may be a value known only after apply (e.g. a TGW you
+create in the same Terraform configuration) — the toggle is the separate
+`enable_transit_gateway` bool, so this does not break planning.
+
+**You must provide the egress path.** Quilt owns only the VPC→TGW leg. Before
+apply, your TGW must:
+
+- be reachable from the deployment account — share it via AWS RAM and accept
+  the VPC attachment (or enable auto-accept) if the TGW lives in another
+  account;
+- have route tables that forward the VPC's egress out to the internet (e.g. via
+  a central egress VPC / NAT) **and** route return traffic back to the VPC's
+  CIDR.
+
+**CIDR uniqueness:** a TGW cannot route between overlapping CIDRs, so any VPCs
+attached to the same TGW must have non-overlapping ranges. Set `cidr`
+accordingly if more than one Quilt stack shares a TGW (the default is
+`10.0.0.0/16`).
+
+**IPv6** egress through the TGW is opt-in (`transit_gateway_ipv6_egress`,
+default `false`). Enable it only if your TGW actually carries IPv6 egress;
+otherwise leave it off — IPv6 then has no default route and falls back to IPv4,
+rather than being black-holed at a TGW that can't route it.
+
+**Reversibility:** removing `enable_transit_gateway` (or setting it `false`)
+restores the NAT gateways and IPv6 egress-only IGW. Toggling it on or off for an
+already-deployed VPC recreates/destroys NAT gateways and their Elastic IPs and
+briefly interrupts egress, so do it in a maintenance window.
+
 ### Profile
 You may wish to set a specific AWS profile before executing `terraform`
 commands.

--- a/README.md
+++ b/README.md
@@ -812,9 +812,13 @@ accordingly if more than one Quilt stack shares a TGW (the default is
 `10.0.0.0/16`).
 
 **IPv6** egress through the TGW is opt-in (`transit_gateway_ipv6_egress`,
-default `false`). Enable it only if your TGW actually carries IPv6 egress;
-otherwise leave it off — IPv6 then has no default route and falls back to IPv4,
-rather than being black-holed at a TGW that can't route it.
+default `false`). The VPC is dual-stack, so set this `true` **only if your TGW
+actually carries IPv6 egress**: pointing `::/0` at a TGW that can't route IPv6
+black-holes those packets, and clients without Happy Eyeballs (e.g. Python's
+`requests`/`urllib3`) then stall on the connection timeout before falling back
+to IPv4. Left `false`, the new VPC has no IPv6 default route, so an IPv6
+attempt fails immediately (`ENETUNREACH`) and the client uses IPv4 with no
+delay.
 
 **Reversibility:** removing `enable_transit_gateway` (or setting it `false`)
 restores the NAT gateways and IPv6 egress-only IGW. Toggling it on or off for an

--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ create in the same Terraform configuration) — the toggle is the separate
 **You must provide the egress path.** Quilt owns only the VPC→TGW leg. Before
 apply, your TGW must:
 
-- be reachable from the deployment account — share it via AWS RAM and accept
+- be reachable from the deployment account — share it via [AWS Resource Access Manager](https://aws.amazon.com/ram/) and accept
   the VPC attachment (or enable auto-accept) if the TGW lives in another
   account;
 - have route tables that forward the VPC's egress out to the internet (e.g. via
@@ -814,7 +814,7 @@ accordingly if more than one Quilt stack shares a TGW (the default is
 **IPv6** egress through the TGW is opt-in (`transit_gateway_ipv6_egress`,
 default `false`). The VPC is dual-stack, so set this `true` **only if your TGW
 actually carries IPv6 egress**: pointing `::/0` at a TGW that can't route IPv6
-black-holes those packets, and clients without Happy Eyeballs (e.g. Python's
+black-holes those packets, and clients without [Happy Eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs) IPv6+IPv4 dual stack support (e.g. Python's
 `requests`/`urllib3`) then stall on the connection timeout before falling back
 to IPv4. Left `false`, the new VPC has no IPv6 default route, so an IPv6
 attempt fails immediately (`ENETUNREACH`) and the client uses IPv4 with no

--- a/README.md
+++ b/README.md
@@ -799,9 +799,9 @@ create in the same Terraform configuration) — the toggle is the separate
 **You must provide the egress path.** Quilt owns only the VPC→TGW leg. Before
 apply, your TGW must:
 
-- be reachable from the deployment account — share it via [AWS Resource Access Manager](https://aws.amazon.com/ram/) and accept
-  the VPC attachment (or enable auto-accept) if the TGW lives in another
-  account;
+- be reachable from the deployment account — share it via
+  [AWS Resource Access Manager](https://aws.amazon.com/ram/) and accept the VPC
+  attachment (or enable auto-accept) if the TGW lives in another account;
 - have route tables that forward the VPC's egress out to the internet (e.g. via
   a central egress VPC / NAT) **and** route return traffic back to the VPC's
   CIDR.
@@ -814,8 +814,10 @@ accordingly if more than one Quilt stack shares a TGW (the default is
 **IPv6** egress through the TGW is opt-in (`transit_gateway_ipv6_egress`,
 default `false`). The VPC is dual-stack, so set this `true` **only if your TGW
 actually carries IPv6 egress**: pointing `::/0` at a TGW that can't route IPv6
-black-holes those packets, and clients without [Happy Eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs) IPv6+IPv4 dual stack support (e.g. Python's
-`requests`/`urllib3`) then stall on the connection timeout before falling back
+black-holes those packets, and clients without
+[Happy Eyeballs](https://en.wikipedia.org/wiki/Happy_Eyeballs) IPv6+IPv4 dual
+stack support (e.g. Python's `requests`/`urllib3`) then stall on the connection
+timeout before falling back
 to IPv4. Left `false`, the new VPC has no IPv6 default route, so an IPv6
 attempt fails immediately (`ENETUNREACH`) and the client uses IPv4 with no
 delay.

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -26,6 +26,9 @@ This document provides comprehensive documentation for all variables available i
 | `user_subnets` | `list(string)` | `null` | ALB subnet IDs (exactly 2 required for internal ALB with existing VPC) |
 | `user_security_group` | `string` | `null` | Security group ID for ALB access (required for existing VPC) |
 | `api_endpoint` | `string` | `null` | VPC endpoint ID for API Gateway (required for internal ALB with existing VPC) |
+| `enable_transit_gateway` | `bool` | `false` | Route private-subnet egress through a Transit Gateway instead of NAT gateways (`create_new_vpc = true` only). Disables NAT + the IPv6 egress-only IGW; requires `transit_gateway_id`. See [Transit Gateway egress](README.md#transit-gateway-egress). |
+| `transit_gateway_id` | `string` | `null` | Transit Gateway to attach to (required when `enable_transit_gateway = true`). May be a value known only after apply (e.g. a TGW created in the same configuration). |
+| `transit_gateway_ipv6_egress` | `bool` | `false` | Also route IPv6 (`::/0`) egress through the TGW. Leave off unless the TGW carries IPv6 egress, otherwise IPv6 traffic would be black-holed. |
 
 ### Database Configuration Variables
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -137,7 +137,9 @@ module "quilt" {
   # user_security_group = "sg-YOUR-SECURITY-GROUP"                           # For ALB access
   # user_subnets        = ["subnet-YOUR-USER-1", "subnet-YOUR-USER-2"]  # For ALB (if internal = true)
   # api_endpoint        = "vpce-YOUR-VPC-ENDPOINT"                         # VPC endpoint (if internal = true)
-  # transit_gateway_id  = "tgw-YOUR-TRANSIT-GATEWAY-ID"                    # For TGW egress when create_new_vpc = true
+  # enable_transit_gateway = true                                          # Route private-subnet egress via a TGW instead of NAT (create_new_vpc = true only)
+  # transit_gateway_id     = "tgw-YOUR-TRANSIT-GATEWAY-ID"                  # Required when enable_transit_gateway = true; the TGW must route to the internet and back
+  # transit_gateway_ipv6_egress = true                                     # Only if the TGW carries IPv6 egress (otherwise IPv6 is left on IPv4 fallback)
 
   # CloudFormation notifications (optional)
   # stack_notification_arns = ["arn:aws:sns:YOUR-AWS-REGION:YOUR-ACCOUNT-ID:quilt-notifications"]

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -143,6 +143,7 @@ module "quilt" {
   # user_security_group = "sg-YOUR-SECURITY-GROUP"                           # For ALB access
   # user_subnets        = ["subnet-YOUR-USER-1", "subnet-YOUR-USER-2"]  # For ALB (if internal = true)
   # api_endpoint        = "vpce-YOUR-VPC-ENDPOINT"                         # VPC endpoint (if internal = true)
+  # transit_gateway_id  = "tgw-YOUR-TRANSIT-GATEWAY-ID"                    # For TGW egress when create_new_vpc = true
 
   # CloudFormation notifications (optional)
   # stack_notification_arns = ["arn:aws:sns:YOUR-AWS-REGION:YOUR-ACCOUNT-ID:quilt-notifications"]

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -139,7 +139,7 @@ module "quilt" {
   # api_endpoint        = "vpce-YOUR-VPC-ENDPOINT"                         # VPC endpoint (if internal = true)
   # enable_transit_gateway = true                                          # Route private-subnet egress via a TGW instead of NAT (create_new_vpc = true only)
   # transit_gateway_id     = "tgw-YOUR-TRANSIT-GATEWAY-ID"                  # Required when enable_transit_gateway = true; the TGW must route to the internet and back
-  # transit_gateway_ipv6_egress = true                                     # Only if the TGW carries IPv6 egress (otherwise IPv6 is left on IPv4 fallback)
+  # transit_gateway_ipv6_egress = true                                     # Only if the TGW carries IPv6 egress; off = no IPv6 default route (clients use IPv4)
 
   # CloudFormation notifications (optional)
   # stack_notification_arns = ["arn:aws:sns:YOUR-AWS-REGION:YOUR-ACCOUNT-ID:quilt-notifications"]

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -14,7 +14,8 @@ module "vpc" {
   cidr     = var.cidr
   internal = var.internal
 
-  transit_gateway_id = var.transit_gateway_id
+  transit_gateway_id          = var.transit_gateway_id
+  transit_gateway_ipv6_egress = var.transit_gateway_ipv6_egress
 
   create_new_vpc               = var.create_new_vpc
   existing_api_endpoint        = var.api_endpoint

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -14,6 +14,8 @@ module "vpc" {
   cidr     = var.cidr
   internal = var.internal
 
+  transit_gateway_id = var.transit_gateway_id
+
   create_new_vpc               = var.create_new_vpc
   existing_api_endpoint        = var.api_endpoint
   existing_vpc_id              = var.vpc_id

--- a/modules/quilt/main.tf
+++ b/modules/quilt/main.tf
@@ -14,6 +14,7 @@ module "vpc" {
   cidr     = var.cidr
   internal = var.internal
 
+  enable_transit_gateway      = var.enable_transit_gateway
   transit_gateway_id          = var.transit_gateway_id
   transit_gateway_ipv6_egress = var.transit_gateway_ipv6_egress
 

--- a/modules/quilt/tests/smoke/main.tf
+++ b/modules/quilt/tests/smoke/main.tf
@@ -66,6 +66,11 @@ variable "user_subnets" {
   default = null
 }
 
+variable "enable_transit_gateway" {
+  type    = bool
+  default = false
+}
+
 variable "transit_gateway_id" {
   type    = string
   default = null
@@ -84,6 +89,7 @@ module "quilt" {
   name                        = "quilt-test"
   parameters                  = {}
   template_file               = "${path.module}/fixtures/quilt.yaml"
+  enable_transit_gateway      = var.enable_transit_gateway
   transit_gateway_id          = var.transit_gateway_id
   transit_gateway_ipv6_egress = var.transit_gateway_ipv6_egress
 

--- a/modules/quilt/tests/smoke/main.tf
+++ b/modules/quilt/tests/smoke/main.tf
@@ -67,14 +67,20 @@ variable "user_subnets" {
   default = null
 }
 
+variable "transit_gateway_id" {
+  type    = string
+  default = null
+}
+
 # New inputs added to the quilt module must be threaded through here, or the
 # smoke coverage silently narrows (the new input is never exercised).
 module "quilt" {
   source = "../../"
 
-  name          = "quilt-test"
-  parameters    = {}
-  template_file = "${path.module}/fixtures/quilt.yaml"
+  name               = "quilt-test"
+  parameters         = {}
+  template_file      = "${path.module}/fixtures/quilt.yaml"
+  transit_gateway_id = var.transit_gateway_id
 
   create_new_vpc      = var.create_new_vpc
   internal            = var.internal

--- a/modules/quilt/tests/smoke/main.tf
+++ b/modules/quilt/tests/smoke/main.tf
@@ -72,15 +72,21 @@ variable "transit_gateway_id" {
   default = null
 }
 
+variable "transit_gateway_ipv6_egress" {
+  type    = bool
+  default = false
+}
+
 # New inputs added to the quilt module must be threaded through here, or the
 # smoke coverage silently narrows (the new input is never exercised).
 module "quilt" {
   source = "../../"
 
-  name               = "quilt-test"
-  parameters         = {}
-  template_file      = "${path.module}/fixtures/quilt.yaml"
-  transit_gateway_id = var.transit_gateway_id
+  name                        = "quilt-test"
+  parameters                  = {}
+  template_file               = "${path.module}/fixtures/quilt.yaml"
+  transit_gateway_id          = var.transit_gateway_id
+  transit_gateway_ipv6_egress = var.transit_gateway_ipv6_egress
 
   create_new_vpc      = var.create_new_vpc
   internal            = var.internal

--- a/modules/quilt/tests/smoke/smoke.tftest.hcl
+++ b/modules/quilt/tests/smoke/smoke.tftest.hcl
@@ -44,6 +44,21 @@ run "new_vpc_transit_gateway_plans" {
   }
 }
 
+run "new_vpc_transit_gateway_ipv6_plans" {
+  command = plan
+  variables {
+    create_new_vpc              = true
+    internal                    = false
+    transit_gateway_id          = "tgw-00000000000000000"
+    transit_gateway_ipv6_egress = true
+  }
+  # TGW egress with IPv6 opted in must also plan end-to-end.
+  assert {
+    condition     = output.stack_name == "quilt-test"
+    error_message = "The CloudFormation stack must be named after var.name"
+  }
+}
+
 run "new_vpc_internal_plans" {
   command = plan
   variables {

--- a/modules/quilt/tests/smoke/smoke.tftest.hcl
+++ b/modules/quilt/tests/smoke/smoke.tftest.hcl
@@ -35,9 +35,10 @@ run "new_vpc_plans" {
 run "new_vpc_transit_gateway_plans" {
   command = plan
   variables {
-    create_new_vpc     = true
-    internal           = false
-    transit_gateway_id = "tgw-00000000000000000"
+    create_new_vpc         = true
+    internal               = false
+    enable_transit_gateway = true
+    transit_gateway_id     = "tgw-00000000000000000"
   }
   # TGW egress mode on a new VPC must plan end-to-end through the public module.
   assert {
@@ -51,6 +52,7 @@ run "new_vpc_transit_gateway_ipv6_plans" {
   variables {
     create_new_vpc              = true
     internal                    = false
+    enable_transit_gateway      = true
     transit_gateway_id          = "tgw-00000000000000000"
     transit_gateway_ipv6_egress = true
   }

--- a/modules/quilt/tests/smoke/smoke.tftest.hcl
+++ b/modules/quilt/tests/smoke/smoke.tftest.hcl
@@ -30,6 +30,20 @@ run "new_vpc_plans" {
   }
 }
 
+run "new_vpc_transit_gateway_plans" {
+  command = plan
+  variables {
+    create_new_vpc     = true
+    internal           = false
+    transit_gateway_id = "tgw-00000000000000000"
+  }
+  # TGW egress mode on a new VPC must plan end-to-end through the public module.
+  assert {
+    condition     = output.stack_name == "quilt-test"
+    error_message = "The CloudFormation stack must be named after var.name"
+  }
+}
+
 run "new_vpc_internal_plans" {
   command = plan
   variables {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -29,10 +29,16 @@ variable "internal" {
   description = "If true create an inward ELBv2, else create an internet-facing ELBv2."
 }
 
+variable "enable_transit_gateway" {
+  type        = bool
+  default     = false
+  description = "Route private subnet egress through a Transit Gateway instead of NAT gateways. Only supported when create_new_vpc == true. When true, transit_gateway_id is required, and NAT gateways and the IPv6 egress-only gateway are disabled. (Toggle is a separate bool so transit_gateway_id may be a value known only after apply, e.g. a TGW created in the same configuration.)"
+}
+
 variable "transit_gateway_id" {
   type        = string
   default     = null
-  description = "Transit Gateway ID for private subnet egress when creating a new VPC. Only supported when create_new_vpc == true. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+  description = "Transit Gateway ID for private subnet egress when creating a new VPC. Required when enable_transit_gateway == true; may be a computed value (e.g. a TGW created in the same configuration)."
   validation {
     condition     = var.transit_gateway_id == null || can(regex("^tgw-[0-9a-f]+$", var.transit_gateway_id))
     error_message = "transit_gateway_id must be null or a valid Transit Gateway ID (e.g. tgw-0123456789abcdef0)."
@@ -42,7 +48,7 @@ variable "transit_gateway_id" {
 variable "transit_gateway_ipv6_egress" {
   type        = bool
   default     = false
-  description = "When transit_gateway_id is set, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when transit_gateway_id is null."
+  description = "When enable_transit_gateway is true, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when enable_transit_gateway is false."
 }
 
 variable "db_snapshot_identifier" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -38,7 +38,7 @@ variable "enable_transit_gateway" {
 variable "transit_gateway_id" {
   type        = string
   default     = null
-  description = "Transit Gateway ID for private subnet egress when creating a new VPC. Required when enable_transit_gateway == true; may be a computed value (e.g. a TGW created in the same configuration)."
+  description = "Transit Gateway ID for private subnet egress. Required when enable_transit_gateway == true; may be a computed value (e.g. a TGW created in the same configuration)."
   validation {
     condition     = var.transit_gateway_id == null || can(regex("^tgw-[0-9a-f]+$", var.transit_gateway_id))
     error_message = "transit_gateway_id must be null or a valid Transit Gateway ID (e.g. tgw-0123456789abcdef0)."

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -48,7 +48,7 @@ variable "transit_gateway_id" {
 variable "transit_gateway_ipv6_egress" {
   type        = bool
   default     = false
-  description = "When enable_transit_gateway is true, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when enable_transit_gateway is false."
+  description = "When enable_transit_gateway is true, also route IPv6 (::/0) egress through the Transit Gateway. Set true only if the Transit Gateway carries IPv6 egress: pointing ::/0 at a TGW that can't route IPv6 black-holes the traffic and stalls clients without Happy Eyeballs (e.g. Python requests/urllib3) on the connection timeout. Left false (default), the VPC has no IPv6 default route, so IPv6 attempts fail immediately and clients use IPv4 with no delay. No effect when enable_transit_gateway is false."
 }
 
 variable "db_snapshot_identifier" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -29,6 +29,12 @@ variable "internal" {
   description = "If true create an inward ELBv2, else create an internet-facing ELBv2."
 }
 
+variable "transit_gateway_id" {
+  type        = string
+  default     = null
+  description = "Transit Gateway ID for private subnet egress when creating a new VPC. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+}
+
 variable "db_snapshot_identifier" {
   type        = string
   nullable    = true

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -32,7 +32,11 @@ variable "internal" {
 variable "transit_gateway_id" {
   type        = string
   default     = null
-  description = "Transit Gateway ID for private subnet egress when creating a new VPC. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+  description = "Transit Gateway ID for private subnet egress when creating a new VPC. Only supported when create_new_vpc == true. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+  validation {
+    condition     = var.transit_gateway_id == null || can(regex("^tgw-[0-9a-f]+$", var.transit_gateway_id))
+    error_message = "transit_gateway_id must be null or a valid Transit Gateway ID (e.g. tgw-0123456789abcdef0)."
+  }
 }
 
 variable "db_snapshot_identifier" {

--- a/modules/quilt/variables.tf
+++ b/modules/quilt/variables.tf
@@ -39,6 +39,12 @@ variable "transit_gateway_id" {
   }
 }
 
+variable "transit_gateway_ipv6_egress" {
+  type        = bool
+  default     = false
+  description = "When transit_gateway_id is set, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when transit_gateway_id is null."
+}
+
 variable "db_snapshot_identifier" {
   type        = string
   nullable    = true

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -33,6 +33,11 @@ locals {
   new_network_valid      = alltrue(values(local.new_network_requires))
   configuration_error    = !local.existing_network_valid && !local.new_network_valid
 
+  # TGW egress is gated on the bool (not transit_gateway_id != null) so the
+  # resource counts stay known at plan time even when transit_gateway_id is a
+  # computed value (e.g. a TGW created in the same configuration).
+  transit_gateway_enabled = local.new_network_valid && var.enable_transit_gateway
+
   azs          = slice(data.aws_availability_zones.available.names, 0, 2)
   subnet_cidrs = [for k, v in local.azs : cidrsubnet(var.cidr, 1, k)]
 }
@@ -78,11 +83,11 @@ module "vpc" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
-  # Gate on the bool, not on transit_gateway_id != null: count must be known at
-  # plan time, and transit_gateway_id may be a computed value (e.g. a TGW
-  # created in the same configuration).
-  count = local.new_network_valid && var.enable_transit_gateway ? 1 : 0
+  count = local.transit_gateway_enabled ? 1 : 0
 
+  # Intra subnets only host the attachment ENIs (they have no internet route).
+  # The egress default routes go in the private route tables below — don't move
+  # this to private_subnets.
   subnet_ids         = module.vpc.intra_subnets
   transit_gateway_id = var.transit_gateway_id
   vpc_id             = module.vpc.vpc_id
@@ -101,7 +106,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
 }
 
 resource "aws_route" "private_tgw_ipv4_egress" {
-  count = local.new_network_valid && var.enable_transit_gateway ? length(module.vpc.private_route_table_ids) : 0
+  count = local.transit_gateway_enabled ? length(module.vpc.private_route_table_ids) : 0
 
   route_table_id         = module.vpc.private_route_table_ids[count.index]
   destination_cidr_block = "0.0.0.0/0"
@@ -111,7 +116,7 @@ resource "aws_route" "private_tgw_ipv4_egress" {
 }
 
 resource "aws_route" "private_tgw_ipv6_egress" {
-  count = local.new_network_valid && var.enable_transit_gateway && var.transit_gateway_ipv6_egress ? length(module.vpc.private_route_table_ids) : 0
+  count = local.transit_gateway_enabled && var.transit_gateway_ipv6_egress ? length(module.vpc.private_route_table_ids) : 0
 
   route_table_id              = module.vpc.private_route_table_ids[count.index]
   destination_ipv6_cidr_block = "::/0"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -17,6 +17,7 @@ locals {
     "user_security_group (required)" : var.existing_user_security_group != null,
     "user_subnets (required if var.internal == true and var.create_new_vpc == false, else must be null)" : (var.internal && !var.create_new_vpc) == (var.existing_user_subnets != null)
     "api_endpoint (required if var.internal == true, else must be null)" : var.internal == (var.existing_api_endpoint != null),
+    "transit_gateway_id == null (TGW egress requires create_new_vpc == true)" : var.transit_gateway_id == null,
   }
   new_network_requires = {
     "create_new_vpc == true" : var.create_new_vpc == true,
@@ -27,7 +28,6 @@ locals {
     "user_security_group == null" : var.existing_user_security_group == null,
     "user_subnets == null" : var.existing_user_subnets == null,
     "api_endpoint == null" : var.existing_api_endpoint == null,
-    "transit_gateway_id == null (TGW egress requires create_new_vpc == true)" : var.transit_gateway_id == null,
   }
   existing_network_valid = alltrue(values(local.existing_network_requires))
   new_network_valid      = alltrue(values(local.new_network_requires))

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -17,7 +17,7 @@ locals {
     "user_security_group (required)" : var.existing_user_security_group != null,
     "user_subnets (required if var.internal == true and var.create_new_vpc == false, else must be null)" : (var.internal && !var.create_new_vpc) == (var.existing_user_subnets != null)
     "api_endpoint (required if var.internal == true, else must be null)" : var.internal == (var.existing_api_endpoint != null),
-    "transit_gateway_id == null (TGW egress requires create_new_vpc == true)" : var.transit_gateway_id == null,
+    "enable_transit_gateway == false (TGW egress requires create_new_vpc == true)" : var.enable_transit_gateway == false,
   }
   new_network_requires = {
     "create_new_vpc == true" : var.create_new_vpc == true,
@@ -72,13 +72,16 @@ module "vpc" {
 
   enable_dns_hostnames   = true
   enable_dns_support     = true
-  enable_nat_gateway     = var.transit_gateway_id == null
-  one_nat_gateway_per_az = var.transit_gateway_id == null
-  create_egress_only_igw = var.transit_gateway_id == null
+  enable_nat_gateway     = !var.enable_transit_gateway
+  one_nat_gateway_per_az = !var.enable_transit_gateway
+  create_egress_only_igw = !var.enable_transit_gateway
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
-  count = local.new_network_valid && var.transit_gateway_id != null ? 1 : 0
+  # Gate on the bool, not on transit_gateway_id != null: count must be known at
+  # plan time, and transit_gateway_id may be a computed value (e.g. a TGW
+  # created in the same configuration).
+  count = local.new_network_valid && var.enable_transit_gateway ? 1 : 0
 
   subnet_ids         = module.vpc.intra_subnets
   transit_gateway_id = var.transit_gateway_id
@@ -88,10 +91,17 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
   tags = {
     Name = "${var.name}-egress"
   }
+
+  lifecycle {
+    precondition {
+      condition     = var.transit_gateway_id != null
+      error_message = "transit_gateway_id is required when enable_transit_gateway is true."
+    }
+  }
 }
 
 resource "aws_route" "private_tgw_ipv4_egress" {
-  count = local.new_network_valid && var.transit_gateway_id != null ? length(module.vpc.private_route_table_ids) : 0
+  count = local.new_network_valid && var.enable_transit_gateway ? length(module.vpc.private_route_table_ids) : 0
 
   route_table_id         = module.vpc.private_route_table_ids[count.index]
   destination_cidr_block = "0.0.0.0/0"
@@ -101,7 +111,7 @@ resource "aws_route" "private_tgw_ipv4_egress" {
 }
 
 resource "aws_route" "private_tgw_ipv6_egress" {
-  count = local.new_network_valid && var.transit_gateway_id != null && var.transit_gateway_ipv6_egress ? length(module.vpc.private_route_table_ids) : 0
+  count = local.new_network_valid && var.enable_transit_gateway && var.transit_gateway_ipv6_egress ? length(module.vpc.private_route_table_ids) : 0
 
   route_table_id              = module.vpc.private_route_table_ids[count.index]
   destination_ipv6_cidr_block = "::/0"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -82,6 +82,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
   subnet_ids         = module.vpc.intra_subnets
   transit_gateway_id = var.transit_gateway_id
   vpc_id             = module.vpc.vpc_id
+  ipv6_support       = "enable"
 
   tags = {
     Name = "${var.name}-egress"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -83,7 +83,7 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
   subnet_ids         = module.vpc.intra_subnets
   transit_gateway_id = var.transit_gateway_id
   vpc_id             = module.vpc.vpc_id
-  ipv6_support       = "enable"
+  ipv6_support       = var.transit_gateway_ipv6_egress ? "enable" : "disable"
 
   tags = {
     Name = "${var.name}-egress"
@@ -101,7 +101,7 @@ resource "aws_route" "private_tgw_ipv4_egress" {
 }
 
 resource "aws_route" "private_tgw_ipv6_egress" {
-  count = local.new_network_valid && var.transit_gateway_id != null ? length(module.vpc.private_route_table_ids) : 0
+  count = local.new_network_valid && var.transit_gateway_id != null && var.transit_gateway_ipv6_egress ? length(module.vpc.private_route_table_ids) : 0
 
   route_table_id              = module.vpc.private_route_table_ids[count.index]
   destination_ipv6_cidr_block = "::/0"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -27,6 +27,7 @@ locals {
     "user_security_group == null" : var.existing_user_security_group == null,
     "user_subnets == null" : var.existing_user_subnets == null,
     "api_endpoint == null" : var.existing_api_endpoint == null,
+    "transit_gateway_id == null (TGW egress requires create_new_vpc == true)" : var.transit_gateway_id == null,
   }
   existing_network_valid = alltrue(values(local.existing_network_requires))
   new_network_valid      = alltrue(values(local.new_network_requires))

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -71,8 +71,41 @@ module "vpc" {
 
   enable_dns_hostnames   = true
   enable_dns_support     = true
-  enable_nat_gateway     = true
-  one_nat_gateway_per_az = true
+  enable_nat_gateway     = var.transit_gateway_id == null
+  one_nat_gateway_per_az = var.transit_gateway_id == null
+  create_egress_only_igw = var.transit_gateway_id == null
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "egress" {
+  count = local.new_network_valid && var.transit_gateway_id != null ? 1 : 0
+
+  subnet_ids         = module.vpc.intra_subnets
+  transit_gateway_id = var.transit_gateway_id
+  vpc_id             = module.vpc.vpc_id
+
+  tags = {
+    Name = "${var.name}-egress"
+  }
+}
+
+resource "aws_route" "private_tgw_ipv4_egress" {
+  count = local.new_network_valid && var.transit_gateway_id != null ? length(module.vpc.private_route_table_ids) : 0
+
+  route_table_id         = module.vpc.private_route_table_ids[count.index]
+  destination_cidr_block = "0.0.0.0/0"
+  transit_gateway_id     = var.transit_gateway_id
+
+  depends_on = [aws_ec2_transit_gateway_vpc_attachment.egress]
+}
+
+resource "aws_route" "private_tgw_ipv6_egress" {
+  count = local.new_network_valid && var.transit_gateway_id != null ? length(module.vpc.private_route_table_ids) : 0
+
+  route_table_id              = module.vpc.private_route_table_ids[count.index]
+  destination_ipv6_cidr_block = "::/0"
+  transit_gateway_id          = var.transit_gateway_id
+
+  depends_on = [aws_ec2_transit_gateway_vpc_attachment.egress]
 }
 
 // Module name no longer accurate (see description); changing name causes tf apply to fail

--- a/modules/vpc/tests/validation.tftest.hcl
+++ b/modules/vpc/tests/validation.tftest.hcl
@@ -182,3 +182,67 @@ run "existing_vpc_missing_inputs_is_rejected" {
   # create_new_vpc = false without the required existing_* inputs is incomplete.
   expect_failures = [output.configuration_error]
 }
+
+# --- Transit Gateway egress mode --------------------------------------------
+
+run "new_vpc_with_transit_gateway" {
+  command = plan
+
+  variables {
+    create_new_vpc               = true
+    internal                     = false
+    transit_gateway_id           = "tgw-00000000000000000"
+    existing_vpc_id              = null
+    existing_api_endpoint        = null
+    existing_intra_subnets       = null
+    existing_private_subnets     = null
+    existing_public_subnets      = null
+    existing_user_security_group = null
+    existing_user_subnets        = null
+  }
+
+  # A new VPC with a transit_gateway_id is the supported TGW egress mode and
+  # must plan cleanly.
+  assert {
+    condition     = !strcontains(output.configuration_error, "❌")
+    error_message = "A new VPC with transit_gateway_id must satisfy every requirement"
+  }
+
+  # The TGW attachment and both default egress routes must be planned, pointed
+  # at the supplied gateway.
+  assert {
+    condition     = length(aws_ec2_transit_gateway_vpc_attachment.egress) == 1
+    error_message = "Exactly one TGW VPC attachment must be created"
+  }
+
+  assert {
+    condition     = aws_ec2_transit_gateway_vpc_attachment.egress[0].transit_gateway_id == "tgw-00000000000000000"
+    error_message = "The TGW attachment must target the supplied transit_gateway_id"
+  }
+
+  assert {
+    condition     = length(aws_route.private_tgw_ipv4_egress) > 0 && length(aws_route.private_tgw_ipv6_egress) > 0
+    error_message = "IPv4 and IPv6 default egress routes to the TGW must be planned"
+  }
+}
+
+run "existing_vpc_with_transit_gateway_is_rejected" {
+  command = plan
+
+  variables {
+    create_new_vpc               = false
+    internal                     = false
+    transit_gateway_id           = "tgw-00000000000000000"
+    existing_vpc_id              = "vpc-00000000000000000"
+    existing_api_endpoint        = null
+    existing_intra_subnets       = ["subnet-intra-a", "subnet-intra-b"]
+    existing_private_subnets     = ["subnet-priv-a", "subnet-priv-b"]
+    existing_public_subnets      = ["subnet-pub-a", "subnet-pub-b"]
+    existing_user_security_group = "sg-00000000000000000"
+    existing_user_subnets        = null
+  }
+
+  # transit_gateway_id is only supported with create_new_vpc = true; combining
+  # it with an existing VPC must fail fast rather than silently ignore the id.
+  expect_failures = [output.configuration_error]
+}

--- a/modules/vpc/tests/validation.tftest.hcl
+++ b/modules/vpc/tests/validation.tftest.hcl
@@ -293,3 +293,76 @@ run "existing_vpc_with_transit_gateway_is_rejected" {
   # ignore the request.
   expect_failures = [output.configuration_error]
 }
+
+run "transit_gateway_enabled_without_id_is_rejected" {
+  command = plan
+
+  variables {
+    create_new_vpc               = true
+    internal                     = false
+    enable_transit_gateway       = true
+    transit_gateway_id           = null
+    existing_vpc_id              = null
+    existing_api_endpoint        = null
+    existing_intra_subnets       = null
+    existing_private_subnets     = null
+    existing_public_subnets      = null
+    existing_user_security_group = null
+    existing_user_subnets        = null
+  }
+
+  # enable_transit_gateway = true requires a transit_gateway_id; the attachment
+  # precondition must reject a null id.
+  expect_failures = [aws_ec2_transit_gateway_vpc_attachment.egress]
+}
+
+run "transit_gateway_id_invalid_format_is_rejected" {
+  command = plan
+
+  variables {
+    create_new_vpc               = true
+    internal                     = false
+    enable_transit_gateway       = true
+    transit_gateway_id           = "not-a-tgw-id"
+    existing_vpc_id              = null
+    existing_api_endpoint        = null
+    existing_intra_subnets       = null
+    existing_private_subnets     = null
+    existing_public_subnets      = null
+    existing_user_security_group = null
+    existing_user_subnets        = null
+  }
+
+  # A malformed transit_gateway_id must be rejected by the variable validation.
+  expect_failures = [var.transit_gateway_id]
+}
+
+run "transit_gateway_id_without_enable_is_noop" {
+  command = plan
+
+  variables {
+    create_new_vpc               = true
+    internal                     = false
+    enable_transit_gateway       = false
+    transit_gateway_id           = "tgw-00000000000000000"
+    existing_vpc_id              = null
+    existing_api_endpoint        = null
+    existing_intra_subnets       = null
+    existing_private_subnets     = null
+    existing_public_subnets      = null
+    existing_user_security_group = null
+    existing_user_subnets        = null
+  }
+
+  # transit_gateway_id is the value, enable_transit_gateway is the toggle: an id
+  # set without enabling the mode is a no-op — no attachment, no TGW routes.
+  assert {
+    condition     = length(aws_ec2_transit_gateway_vpc_attachment.egress) == 0
+    error_message = "No TGW attachment should be created when enable_transit_gateway is false"
+  }
+
+  assert {
+    condition     = length(aws_route.private_tgw_ipv4_egress) == 0 && length(aws_route.private_tgw_ipv6_egress) == 0
+    error_message = "No TGW egress routes should be created when enable_transit_gateway is false"
+  }
+}

--- a/modules/vpc/tests/validation.tftest.hcl
+++ b/modules/vpc/tests/validation.tftest.hcl
@@ -208,8 +208,8 @@ run "new_vpc_with_transit_gateway" {
     error_message = "A new VPC with transit_gateway_id must satisfy every requirement"
   }
 
-  # The TGW attachment and both default egress routes must be planned, pointed
-  # at the supplied gateway.
+  # The TGW attachment and the IPv4 default egress route must be planned,
+  # pointed at the supplied gateway.
   assert {
     condition     = length(aws_ec2_transit_gateway_vpc_attachment.egress) == 1
     error_message = "Exactly one TGW VPC attachment must be created"
@@ -221,8 +221,51 @@ run "new_vpc_with_transit_gateway" {
   }
 
   assert {
-    condition     = length(aws_route.private_tgw_ipv4_egress) > 0 && length(aws_route.private_tgw_ipv6_egress) > 0
-    error_message = "IPv4 and IPv6 default egress routes to the TGW must be planned"
+    condition     = length(aws_route.private_tgw_ipv4_egress) > 0
+    error_message = "IPv4 default egress routes to the TGW must be planned"
+  }
+
+  # IPv6 egress via the TGW is opt-in (transit_gateway_ipv6_egress, default
+  # false). With it off, no ::/0 route is created and the attachment does not
+  # advertise IPv6 support, so IPv6 traffic is not black-holed at the TGW.
+  assert {
+    condition     = length(aws_route.private_tgw_ipv6_egress) == 0
+    error_message = "No IPv6 egress route should be planned when transit_gateway_ipv6_egress is false"
+  }
+
+  assert {
+    condition     = aws_ec2_transit_gateway_vpc_attachment.egress[0].ipv6_support == "disable"
+    error_message = "The TGW attachment must not advertise IPv6 support when transit_gateway_ipv6_egress is false"
+  }
+}
+
+run "new_vpc_with_transit_gateway_ipv6_egress" {
+  command = plan
+
+  variables {
+    create_new_vpc               = true
+    internal                     = false
+    transit_gateway_id           = "tgw-00000000000000000"
+    transit_gateway_ipv6_egress  = true
+    existing_vpc_id              = null
+    existing_api_endpoint        = null
+    existing_intra_subnets       = null
+    existing_private_subnets     = null
+    existing_public_subnets      = null
+    existing_user_security_group = null
+    existing_user_subnets        = null
+  }
+
+  # Opting in routes the IPv6 default route through the TGW and enables IPv6
+  # support on the attachment.
+  assert {
+    condition     = length(aws_route.private_tgw_ipv6_egress) > 0
+    error_message = "IPv6 egress routes to the TGW must be planned when transit_gateway_ipv6_egress is true"
+  }
+
+  assert {
+    condition     = aws_ec2_transit_gateway_vpc_attachment.egress[0].ipv6_support == "enable"
+    error_message = "The TGW attachment must advertise IPv6 support when transit_gateway_ipv6_egress is true"
   }
 }
 

--- a/modules/vpc/tests/validation.tftest.hcl
+++ b/modules/vpc/tests/validation.tftest.hcl
@@ -191,6 +191,7 @@ run "new_vpc_with_transit_gateway" {
   variables {
     create_new_vpc               = true
     internal                     = false
+    enable_transit_gateway       = true
     transit_gateway_id           = "tgw-00000000000000000"
     existing_vpc_id              = null
     existing_api_endpoint        = null
@@ -201,7 +202,7 @@ run "new_vpc_with_transit_gateway" {
     existing_user_subnets        = null
   }
 
-  # A new VPC with a transit_gateway_id is the supported TGW egress mode and
+  # A new VPC with enable_transit_gateway is the supported TGW egress mode and
   # must plan cleanly.
   assert {
     condition     = !strcontains(output.configuration_error, "❌")
@@ -245,6 +246,7 @@ run "new_vpc_with_transit_gateway_ipv6_egress" {
   variables {
     create_new_vpc               = true
     internal                     = false
+    enable_transit_gateway       = true
     transit_gateway_id           = "tgw-00000000000000000"
     transit_gateway_ipv6_egress  = true
     existing_vpc_id              = null
@@ -275,6 +277,7 @@ run "existing_vpc_with_transit_gateway_is_rejected" {
   variables {
     create_new_vpc               = false
     internal                     = false
+    enable_transit_gateway       = true
     transit_gateway_id           = "tgw-00000000000000000"
     existing_vpc_id              = "vpc-00000000000000000"
     existing_api_endpoint        = null
@@ -285,7 +288,8 @@ run "existing_vpc_with_transit_gateway_is_rejected" {
     existing_user_subnets        = null
   }
 
-  # transit_gateway_id is only supported with create_new_vpc = true; combining
-  # it with an existing VPC must fail fast rather than silently ignore the id.
+  # enable_transit_gateway is only supported with create_new_vpc = true;
+  # combining it with an existing VPC must fail fast rather than silently
+  # ignore the request.
   expect_failures = [output.configuration_error]
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -42,7 +42,7 @@ variable "transit_gateway_id" {
 variable "transit_gateway_ipv6_egress" {
   type        = bool
   default     = false
-  description = "When enable_transit_gateway is true, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when enable_transit_gateway is false."
+  description = "When enable_transit_gateway is true, also route IPv6 (::/0) egress through the Transit Gateway. Set true only if the Transit Gateway carries IPv6 egress: pointing ::/0 at a TGW that can't route IPv6 black-holes the traffic and stalls clients without Happy Eyeballs (e.g. Python requests/urllib3) on the connection timeout. Left false (default), the VPC has no IPv6 default route, so IPv6 attempts fail immediately and clients use IPv4 with no delay. No effect when enable_transit_gateway is false."
 }
 
 variable "existing_vpc_id" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -23,10 +23,16 @@ variable "internal" {
   nullable = false
 }
 
+variable "enable_transit_gateway" {
+  type        = bool
+  default     = false
+  description = "Route private subnet egress through a Transit Gateway instead of NAT gateways. Only supported when create_new_vpc == true. When true, transit_gateway_id is required, and NAT gateways and the IPv6 egress-only gateway are disabled. (Toggle is a separate bool so transit_gateway_id may be a value known only after apply, e.g. a TGW created in the same configuration.)"
+}
+
 variable "transit_gateway_id" {
   type        = string
   default     = null
-  description = "Transit Gateway ID for private subnet egress. Only supported when create_new_vpc == true. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+  description = "Transit Gateway ID for private subnet egress. Required when enable_transit_gateway == true; may be a computed value (e.g. a TGW created in the same configuration)."
   validation {
     condition     = var.transit_gateway_id == null || can(regex("^tgw-[0-9a-f]+$", var.transit_gateway_id))
     error_message = "transit_gateway_id must be null or a valid Transit Gateway ID (e.g. tgw-0123456789abcdef0)."
@@ -36,7 +42,7 @@ variable "transit_gateway_id" {
 variable "transit_gateway_ipv6_egress" {
   type        = bool
   default     = false
-  description = "When transit_gateway_id is set, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when transit_gateway_id is null."
+  description = "When enable_transit_gateway is true, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when enable_transit_gateway is false."
 }
 
 variable "existing_vpc_id" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -33,6 +33,12 @@ variable "transit_gateway_id" {
   }
 }
 
+variable "transit_gateway_ipv6_egress" {
+  type        = bool
+  default     = false
+  description = "When transit_gateway_id is set, also route the private subnets' IPv6 default route (::/0) through the Transit Gateway. Leave false unless the Transit Gateway is configured for IPv6 egress; otherwise IPv6 traffic would be black-holed (with no route, IPv4 still falls back cleanly). No effect when transit_gateway_id is null."
+}
+
 variable "existing_vpc_id" {
   type = string
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -23,6 +23,12 @@ variable "internal" {
   nullable = false
 }
 
+variable "transit_gateway_id" {
+  type        = string
+  default     = null
+  description = "Transit Gateway ID for private subnet egress. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+}
+
 variable "existing_vpc_id" {
   type = string
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -26,7 +26,11 @@ variable "internal" {
 variable "transit_gateway_id" {
   type        = string
   default     = null
-  description = "Transit Gateway ID for private subnet egress. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+  description = "Transit Gateway ID for private subnet egress. Only supported when create_new_vpc == true. If set, NAT gateways and IPv6 egress-only gateways are disabled."
+  validation {
+    condition     = var.transit_gateway_id == null || can(regex("^tgw-[0-9a-f]+$", var.transit_gateway_id))
+    error_message = "transit_gateway_id must be null or a valid Transit Gateway ID (e.g. tgw-0123456789abcdef0)."
+  }
 }
 
 variable "existing_vpc_id" {


### PR DESCRIPTION
> **For reviewers:** picked up from the original author @drernie — @sir-sigurd is now carrying this PR through review (direct questions here, not to @drernie).

## What is changing
This adds a first-class Transit Gateway egress mode to the Terraform `quilt`/`vpc` modules. When `enable_transit_gateway = true` (with `transit_gateway_id`) while creating a new VPC, Quilt still owns the VPC, subnets, endpoints, and route tables, but it disables NAT gateways and the IPv6 egress-only IGW, creates a TGW VPC attachment in the intra subnets, and points each private route table's IPv4 default route at the TGW. `transit_gateway_id` may be a value known only after apply (e.g. a TGW created in the same configuration) — the toggle is the separate `enable_transit_gateway` bool, so `count` stays resolvable at plan time. IPv6 egress through the TGW is opt-in via `transit_gateway_ipv6_egress` (default off, since not every TGW carries IPv6); when enabled it points the IPv6 default route at the TGW and enables IPv6 support on the attachment. Set it `true` only if the TGW actually carries IPv6 egress, since pointing `::/0` at a TGW that can't route IPv6 black-holes the traffic and stalls clients without Happy Eyeballs (e.g. Python). With it off, the new VPC has no IPv6 default route, so an IPv6 attempt fails immediately and the client uses IPv4 with no delay.

## Why
A customer needs Quilt-created infrastructure to egress through an existing network path instead of Quilt-created NAT gateways. This keeps the deployment on the supported Terraform path while letting the customer supply the TGW as the egress boundary.

## What was considered
- Customer-owned VPCs were set aside because they recreate the unsupported VPC-module mismatch this work is meant to remove.
- Out-of-band route table edits were set aside because Quilt updates would not own or preserve that topology.
- Using `transit_gateway_id != null` as the sole toggle was set aside: that gates resource `count`, which must be known at plan time, so a `transit_gateway_id` created in the same configuration (a computed value) would fail with "Invalid count argument." An explicit `enable_transit_gateway` bool (the idiomatic `enable_*`/`create_*` pattern, mirroring `enable_nat_gateway`) keeps the count plan-resolvable and lets the id be computed, so the TGW can be provisioned in the same config as the stack.

## Risks and reversibility
The apply depends on the customer sharing the TGW into the deployment account and configuring TGW route tables/return paths correctly. If those prerequisites are wrong, attachment or egress validation can fail. The change is reversible by setting `enable_transit_gateway = false`, which restores the existing NAT gateway and IPv6 egress-only IGW behavior for newly-created VPCs.

## Open questions
- The customer must confirm the TGW RAM share, attachment acceptance behavior, and TGW-side route tables before production apply.

## What approval means
Approval means Quilt supports this as the Terraform-owned way to create a new Quilt VPC whose private-subnet default egress routes through a customer-provided TGW.

## Validation

### Automated (CI, no AWS credentials, no infrastructure)
- `terraform fmt -check -recursive` and `terraform validate` for all modules.
- `terraform test` in `modules/vpc` — plan-time, mocked-provider tests of the new-vs-existing network input validation, including TGW egress: a new VPC with `enable_transit_gateway = true` plans and creates the attachment + the IPv4 default egress route (and the IPv6 route only when `transit_gateway_ipv6_egress` is set); existing-VPC + `enable_transit_gateway` is rejected.
- `terraform test` in `modules/quilt/tests/smoke` — plan-time smoke test of the public module against a mocked provider, including the TGW path.
- These run in CI alongside `fmt`/`validate`.

### End-to-end (live, on an internal dev stack)
Deployed a full Quilt stack with `enable_transit_gateway = true` — the TGW created in the *same* configuration (computed `transit_gateway_id`), NAT gateways disabled — and confirmed egress actually flows through the TGW:
- The CloudFormation stack reached `CREATE_COMPLETE` and the catalog served traffic.
- Outbound control-plane egress succeeded: license validation, transactional email (a password-reset email was delivered), SSO/OIDC login, and Mixpanel telemetry (the failure-silent path — events were received for the stack).
- NAT and TGW byte/connection metrics were non-zero, and an in-container check from the registry reported its public egress IP equal to the egress VPC's NAT address — i.e. traffic exits private subnet → TGW → egress VPC NAT → internet.
- Also confirms the computed-`transit_gateway_id` path applies cleanly (no "Invalid count argument").
- Verified teardown: removing the stack disables the mode and restores normal egress.

## Links
- PR: https://github.com/quiltdata/iac/pull/115

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a first-class Transit Gateway egress mode to the `vpc` and `quilt` modules. When `enable_transit_gateway = true` (only with `create_new_vpc = true`), the module disables NAT gateways and the IPv6 egress-only IGW, creates a TGW VPC attachment in the intra subnets, and routes each private route table's default IPv4 (and optionally IPv6) egress through the TGW.

- **Core toggle design**: The `enable_transit_gateway` bool gates all resource `count` expressions, while `transit_gateway_id` can be a computed/unknown value — this avoids the "Invalid count argument" planning error that would occur if the count depended on a not-yet-known TGW ID.
- **Validation coverage**: Invalid combinations (existing VPC + TGW, enabled-without-id, bad-format ID, id-without-enable) are all covered by separate `expect_failures` tests in `modules/vpc/tests/validation.tftest.hcl`, plus positive-path smoke tests threaded through `modules/quilt`.
- **Documentation**: README, CHANGELOG, VARIABLES.md, and `examples/main.tf` are updated consistently, with clear reversibility and egress-IP-change warnings.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The toggle design is architecturally sound, validation coverage is comprehensive, and the end-to-end test confirms the computed-ID path works correctly.

The transit_gateway_enabled local correctly ties all resource counts to new_network_valid && var.enable_transit_gateway — both values are known at plan time, preventing Invalid count argument even when transit_gateway_id is computed. The lifecycle precondition catches the null-ID case, the variable validation rejects malformed IDs, and the existing_network_requires map blocks the unsupported existing-VPC combination. All seven new test cases (positive and negative paths) exercise these invariants, and the PR's end-to-end validation confirms the full flow on a live stack.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/vpc/main.tf | Core TGW implementation: attachment in intra subnets, IPv4/IPv6 routes in private route tables, NAT/egress-IGW disabled via !var.enable_transit_gateway, transit_gateway_enabled local gates all counts on new_network_valid. Logic is correct and well-commented. |
| modules/vpc/variables.tf | Three new variables with correct defaults, descriptions, and a regex format-validation on transit_gateway_id (null-safe, skipped for unknown computed values). |
| modules/vpc/tests/validation.tftest.hcl | Seven new test cases covering positive paths (IPv4-only, IPv4+IPv6), existing-VPC rejection, enabled-without-id rejection, bad-format-id rejection, and id-without-enable no-op. Full assertion coverage of attachment attributes and route counts. |
| modules/quilt/variables.tf | Mirrors vpc module's three new variables with identical descriptions and the same transit_gateway_id format validation; correctly passes through to the vpc submodule. |
| modules/quilt/tests/smoke/smoke.tftest.hcl | Two new smoke runs (IPv4-only TGW and IPv4+IPv6 TGW) confirm the full quilt module wires end-to-end; negative-path tests are intentionally left to the vpc validation suite. |
| modules/quilt/main.tf | Three new variable pass-throughs to the vpc submodule; straightforward and correct. |
| README.md | New Transit Gateway egress section with HCL example, prerequisites checklist, CIDR uniqueness note, IPv6 opt-in warning, and reversibility/egress-IP-change advisory. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([enable_transit_gateway]) -->|true| B{new_network_valid?}
    A -->|false| NAT[NAT gateways + egress-only IGW]
    B -->|false| ERR[configuration_error precondition fires]
    B -->|true| C[transit_gateway_enabled = true]
    C --> D[aws_ec2_transit_gateway_vpc_attachment.egress count=1]
    D --> PREC{transit_gateway_id != null?}
    PREC -->|false| FAIL[Precondition failure]
    PREC -->|true| E[IPv4 routes: aws_route.private_tgw_ipv4_egress x N private RTs]
    E --> F{transit_gateway_ipv6_egress?}
    F -->|true| G[IPv6 routes: aws_route.private_tgw_ipv6_egress x N private RTs - ipv6_support=enable on attachment]
    F -->|false| H[No IPv6 default route - ipv6_support=disable on attachment]
    NAT --> I[S3 gateway endpoint unchanged in both modes]
    G --> I
    H --> I
```

<sub>Reviews (3): Last reviewed commit: ["Address review follow-up: egress-IP doc,..."](https://github.com/quiltdata/iac/commit/f499603ef0f68bfdecb0c43a92a079b30d1cb3a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35770857)</sub>

<!-- /greptile_comment -->
