### PR TITLE
Bump modules/cnames AWS provider constraint to ~> 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+- [Fixed] Relax `modules/cnames` AWS provider constraint from `~> 5.0` to `>= 5.79, < 7.0` so it resolves alongside the `vpc` module's `aws >= 6.28` requirement — using `quilt` + `cnames` in one root previously failed `terraform init` ([#117](https://github.com/quiltdata/iac/pull/117))
+
 ## [1.7.1] - 2026-06-04
 
 - [Fixed] Pin every registry module with `~>` so an upstream major can't silently break `terraform plan`/`apply` — resolves the `security-group` v6.0.0 break and constrains the rest (`security-group`/`rds` → `~> 5.0`, `vpc` → `~> 6.0`) ([#110](https://github.com/quiltdata/iac/pull/110), [#112](https://github.com/quiltdata/iac/pull/112))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
-- [Fixed] Relax `modules/cnames` AWS provider constraint from `~> 5.0` to `>= 5.79, < 7.0` so it resolves alongside the `vpc` module's `aws >= 6.28` requirement — using `quilt` + `cnames` in one root previously failed `terraform init` ([#117](https://github.com/quiltdata/iac/pull/117))
+- [Fixed] Bump `modules/cnames` AWS provider constraint from `~> 5.0` to `~> 6.0` so it resolves alongside the `vpc` module's `aws >= 6.28` requirement — using `quilt` + `cnames` in one root previously failed `terraform init` ([#117](https://github.com/quiltdata/iac/pull/117))
 
 ## [1.7.1] - 2026-06-04
 

--- a/modules/cnames/main.tf
+++ b/modules/cnames/main.tf
@@ -1,8 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
+      source = "hashicorp/aws"
+      # Span 5.x and 6.x: this module only manages aws_route53_record (stable
+      # across both majors), and it is used alongside the vpc module, whose
+      # terraform-aws-modules/vpc ~> 6.0 dependency requires aws >= 6.28. A
+      # ~> 5.0 pin here made `quilt` + `cnames` unresolvable in one root.
+      version = ">= 5.79, < 7.0"
     }
   }
 }

--- a/modules/cnames/main.tf
+++ b/modules/cnames/main.tf
@@ -1,12 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # Span 5.x and 6.x: this module only manages aws_route53_record (stable
-      # across both majors), and it is used alongside the vpc module, whose
-      # terraform-aws-modules/vpc ~> 6.0 dependency requires aws >= 6.28. A
-      # ~> 5.0 pin here made `quilt` + `cnames` unresolvable in one root.
-      version = ">= 5.79, < 7.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/quilt/tests/smoke/main.tf
+++ b/modules/quilt/tests/smoke/main.tf
@@ -16,8 +16,7 @@ terraform {
       source = "hashicorp/aws"
       # Match what the modules under test transitively require: the
       # terraform-aws-modules/vpc ~> 6.0 module needs aws >= 6.28. Pinning keeps
-      # CI deterministic and off a future major. (Note: examples/main.tf and
-      # modules/cnames still pin ~> 5.0, which is incompatible with that floor.)
+      # CI deterministic and off a future major.
       version = "~> 6.0"
     }
   }
@@ -85,6 +84,20 @@ module "quilt" {
   public_subnets      = var.public_subnets
   user_security_group = var.user_security_group
   user_subnets        = var.user_subnets
+}
+
+# Compose `cnames` in the same root as `quilt` so CI resolves their combined
+# AWS provider constraints at init. This is the regression guard for the
+# quilt (vpc → aws >= 6.28) vs cnames conflict: a future incompatible pin on
+# either module fails `terraform init` here. Inputs are literal dummies — the
+# guard is provider resolution + plan wiring, not value flow from the (mocked)
+# quilt outputs.
+module "cnames" {
+  source = "../../../cnames"
+
+  zone_id        = "Z00000000000000000000"
+  quilt_web_host = "quilt-test.example.com"
+  lb_dns_name    = "test-lb.example.com"
 }
 
 # Re-expose ONLY the non-sensitive stack name. Do not output module.quilt.stack

--- a/modules/quilt/tests/smoke/main.tf
+++ b/modules/quilt/tests/smoke/main.tf
@@ -86,12 +86,9 @@ module "quilt" {
   user_subnets        = var.user_subnets
 }
 
-# Compose `cnames` in the same root as `quilt` so CI resolves their combined
-# AWS provider constraints at init. This is the regression guard for the
-# quilt (vpc → aws >= 6.28) vs cnames conflict: a future incompatible pin on
-# either module fails `terraform init` here. Inputs are literal dummies — the
-# guard is provider resolution + plan wiring, not value flow from the (mocked)
-# quilt outputs.
+# Compose `cnames` with `quilt` so CI's init resolves both modules' AWS
+# provider constraints together — a future incompatible pin fails init here.
+# Inputs are literal dummies; this guards resolution, not value flow.
 module "cnames" {
   source = "../../../cnames"
 

--- a/modules/quilt/tests/smoke/smoke.tftest.hcl
+++ b/modules/quilt/tests/smoke/smoke.tftest.hcl
@@ -4,6 +4,8 @@
 # Plan-only with the AWS provider mocked: no credentials, no infrastructure.
 # Exercises the full wiring (vpc + db + search + the CloudFormation stack), so
 # a change that breaks the public boundary or the vpc pass-through fails in CI.
+# The wrapper also composes the `cnames` module (see main.tf), so an AWS
+# provider constraint that can't resolve across quilt + cnames fails at init.
 #
 # Assertions reference known inputs (the stack name), not mocked computed
 # attributes, whose generated values are intentionally arbitrary.


### PR DESCRIPTION
## Description

`modules/cnames` pinned `aws ~> 5.0` (i.e. `< 6.0`), but it is used in the same root as `modules/quilt` — whose `terraform-aws-modules/vpc ~> 6.0` dependency requires `aws >= 6.28`. The two constraints have no overlap, so any root using both modules (the topology `examples/main.tf` documents) fails `terraform init`:

```
Finding hashicorp/aws versions matching ">= 3.29.0, ~> 5.0, >= 6.28.0"...
Error: no available releases match the given constraints
```

This is the loose end of the registry-pinning sweep in #110/#112: `vpc` and `security-group` were reconciled into the 6.x/5.x world, but `cnames`'s `aws` constraint was never brought along. The break is upstream-timed — `vpc` 6.0.0 only required `aws >= 5.79` (compatible with `~> 5.0`); it activated once the upstream module raised its floor past 6.0.

`cnames` only manages `aws_route53_record`, which is stable across aws 5.x and 6.x, so bumping it to `~> 6.0` (matching the `vpc` module) is safe and lets it resolve into 6.x alongside `vpc`.

Verified locally — a root combining `vpc` + `cnames` now resolves (`aws v6.49.0`) where it previously failed `init`.

It also adds a regression guard: the `quilt` smoke-test wrapper now composes `cnames` in the same root, so CI's `terraform init` resolves both modules' AWS provider constraints together. No CI job did that before — each module is validated standalone — which is why this conflict went unnoticed across releases. A future incompatible pin on either module now fails CI at init.

## TODO

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry
- [ ] *I promise to deploy to dev stacks (including nightly) **soon** after PR is merged so we really have these changes tested*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Terraform provider constraint conflict where `modules/cnames` pinned `aws ~> 5.0` while `modules/quilt`'s transitive dependency (`terraform-aws-modules/vpc ~> 6.0`) requires `aws >= 6.28`, making the two constraints irresolvable in a shared root. The fix bumps `cnames` to `~> 6.0` and adds a regression guard by composing `cnames` into the `quilt` smoke-test wrapper so future constraint divergence fails CI at `terraform init`.

- **`modules/cnames/main.tf`**: Single-line bump from `~> 5.0` to `~> 6.0`; `aws_route53_record` is stable across both major versions so no resource changes are needed.
- **`modules/quilt/tests/smoke/main.tf`**: Adds a `module \"cnames\"` block with valid dummy inputs (all required variables supplied, `ttl` has a default) to make init exercise both modules' provider constraints together.
- **`CHANGELOG.md` / `smoke.tftest.hcl`**: Changelog entry and updated test header comment to document the guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line provider constraint bump with no resource changes and a well-constructed regression guard added to CI.

The fix is minimal and surgical: aws_route53_record has no breaking changes between aws 5.x and 6.x, so bumping the constraint carries no operational risk. The dummy inputs in the smoke wrapper are all valid (required variables supplied, ttl defaults to 60, the quilt_web_host regex matches the supplied value), so the plan-only mocked tests will continue to pass. The regression guard correctly closes the gap that allowed this conflict to go undetected across prior releases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/cnames/main.tf | Bumps AWS provider constraint from `~> 5.0` to `~> 6.0`; `aws_route53_record` is unchanged and stable across both major versions. |
| modules/quilt/tests/smoke/main.tf | Adds `module "cnames"` with all required variables (dummy values valid for plan + regex) and removes now-stale inline note about `cnames` pinning `~> 5.0`. |
| modules/quilt/tests/smoke/smoke.tftest.hcl | Header comment updated to document the new cross-module constraint guard; no test logic changes. |
| CHANGELOG.md | Adds `[Fixed]` entry under `[Unreleased]` accurately describing the constraint conflict and its resolution. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["terraform init (shared root)"] --> B{Resolve aws provider}
    B --> C["modules/cnames\nrequires aws ~> 6.0"]
    B --> D["modules/quilt\n(via vpc ~> 6.0)\nrequires aws >= 6.28"]
    C --> E["Intersection: aws >= 6.0, < 7.0"]
    D --> E
    E --> F["✅ Resolves (e.g. aws v6.49.0)"]

    subgraph "Before this PR"
        G["modules/cnames\nrequires aws ~> 5.0"]
        H["modules/quilt\nrequires aws >= 6.28"]
        G --> I["❌ No overlap — init fails"]
        H --> I
    end

    subgraph "CI Regression Guard"
        J["smoke/main.tf\ncompose quilt + cnames"] --> K["terraform init\nexercises both constraints"]
        K --> L["Future pin conflict\nfails CI at init"]
    end
```

<sub>Reviews (4): Last reviewed commit: ["Tighten cnames guard comment in smoke wr..."](https://github.com/quiltdata/iac/commit/85cf3e024b3d7654ceecff45b9894ed508502df1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36201947)</sub>

<!-- /greptile_comment -->