### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.7.2] - 2026-06-08
+
 - [Fixed] Bump `modules/cnames` AWS provider constraint from `~> 5.0` to `~> 6.0` so it resolves alongside the `vpc` module's `aws >= 6.28` requirement — using `quilt` + `cnames` in one root previously failed `terraform init` ([#117](https://github.com/quiltdata/iac/pull/117))
 
 ## [1.7.1] - 2026-06-04
@@ -96,7 +98,8 @@ Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading 
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))
 
-[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.1...HEAD
+[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.2...HEAD
+[1.7.2]: https://github.com/quiltdata/iac/releases/tag/1.7.2
 [1.7.1]: https://github.com/quiltdata/iac/releases/tag/1.7.1
 [1.7.0]: https://github.com/quiltdata/iac/releases/tag/1.7.0
 [1.6.0]: https://github.com/quiltdata/iac/releases/tag/1.6.0


### PR DESCRIPTION
## Description

CHANGELOG-only release. Rolls the `[Unreleased]` entry under `## [1.7.2] - 2026-06-08` and updates the version link refs; tag `1.7.2` to be created on merge.

Shipping in this release (from #117):
- [Fixed] `modules/cnames` AWS provider constraint `~> 5.0` → `~> 6.0`, so it resolves alongside the `vpc` module's transitive `aws >= 6.28` floor — using `quilt` + `cnames` in one root previously failed `terraform init`.

## TODO

- [x] [CHANGELOG](../tree/main/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

CHANGELOG-only release PR that cuts version 1.7.2. The unreleased `modules/cnames` AWS provider constraint fix (shipped in #117) is moved under a new `## [1.7.2] - 2026-06-08` heading, leaving the `[Unreleased]` section empty for future work.

- The `[Unreleased]` section is now correctly empty and its compare link updated to `1.7.2...HEAD`.
- A new `[1.7.2]` link ref pointing to the GitHub releases tag is appended in the correct position in the reference list.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a single-file CHANGELOG update with no code changes.

The change is purely documentary: it moves an existing fix entry under a versioned heading, empties the [Unreleased] placeholder, and adds the corresponding link ref. All three edits are consistent with each other and with the rest of the file's history.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Promotes the existing fix entry from [Unreleased] to [1.7.2] - 2026-06-08, leaves [Unreleased] empty as a placeholder, and adds the [1.7.2] link ref while updating [Unreleased] to compare from 1.7.2...HEAD. All formatting and link references are correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["[Unreleased] section\n(fix entry from #117)"] -->|"Promote to release"| B["## [1.7.2] - 2026-06-08\n- Fixed: cnames AWS provider ~> 6.0"]
    B --> C["Update link refs"]
    C --> D["[Unreleased] → compare/1.7.2...HEAD"]
    C --> E["[1.7.2] → releases/tag/1.7.2"]
    B --> F["[Unreleased] section\nnow empty (ready for future changes)"]
```

<sub>Reviews (2): Last reviewed commit: ["Release 1.7.2"](https://github.com/quiltdata/iac/commit/d897bcd751399f109fb83b6b773062961281dd8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36221275)</sub>

<!-- /greptile_comment -->