### PR TITLE
Refresh example: pin modules to 1.7.2, drop redundant root aws provider pin

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -42,12 +42,6 @@ terraform {
   }
 
   required_version = ">= 1.10.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
-    }
-  }
 }
 
 # Local variables for configuration

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -45,7 +45,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }
@@ -83,7 +83,7 @@ variable "okta_client_secret" {
 # Main Quilt module
 module "quilt" {
   # Pin to the latest stable version from https://github.com/quiltdata/iac/tags
-  source = "github.com/quiltdata/iac//modules/quilt?ref=1.3.0"
+  source = "github.com/quiltdata/iac//modules/quilt?ref=1.7.2"
 
   name          = local.name
   template_file = local.build_file_path
@@ -199,7 +199,7 @@ module "quilt" {
 
 # DNS configuration (optional but recommended)
 module "cnames" {
-  source = "github.com/quiltdata/iac//modules/cnames?ref=1.3.0"
+  source = "github.com/quiltdata/iac//modules/cnames?ref=1.7.2"
 
   lb_dns_name    = module.quilt.stack.outputs.LoadBalancerDNSName
   quilt_web_host = local.quilt_web_host


### PR DESCRIPTION
## Description

`examples/main.tf` pinned the modules at `ref=1.3.0` (four releases stale) and the root `aws` provider at `~> 5.0`. That combination no longer resolves: the current modules pull `terraform-aws-modules/vpc ~> 6.0`, whose transitive `aws >= 6.28` floor has no overlap with `~> 5.0`, so `terraform init` on the example fails.

With the `cnames` provider fix shipped in 1.7.2 (#117), this bumps both module refs to `1.7.2` and **removes the root `required_providers` block**. That root version pin only duplicated what the pinned modules already require (`vpc → aws >= 6.28`) and was exactly what drifted into the `~> 5.0` conflict; the provider now resolves from the modules' own constraints, so there is no second pin to keep in sync.

Verified: `terraform init` on the example now resolves cleanly (aws **v6.49.0**) where it previously errored on the unsatisfiable provider constraint.

## TODO

- [ ] CHANGELOG entry — N/A: example/doc housekeeping, no module behavior change.
- [ ] *Dev-stack deploy* — N/A: example file only, nothing deployable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `examples/main.tf` to fix a broken `terraform init` caused by a stale `aws ~> 5.0` provider pin that conflicted with the transitive `aws >= 6.28` requirement introduced in `terraform-aws-modules/vpc ~> 6.0`.

- **Module refs bumped**: Both `modules/quilt` and `modules/cnames` are pinned from `ref=1.3.0` to `ref=1.7.2`, bringing the example in sync with the current stable release (including the `cnames` provider fix from #117).
- **Root `required_providers` block removed**: The `aws ~> 5.0` pin is dropped because it duplicated — and conflicted with — the provider constraint already expressed transitively through the pinned modules; provider version selection now flows cleanly from the modules' own constraints (`>= 6.28`), resolving to `aws v6.49.0`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it fixes a broken example and touches only that example file.

The change is scoped entirely to the example file, corrects a verifiable provider constraint conflict, and aligns the pinned module versions with the current stable release. No module logic is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/main.tf | Module refs bumped from 1.3.0 to 1.7.2 for both quilt and cnames; conflicting aws ~> 5.0 root required_providers block removed. Straightforward example maintenance with no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[terraform init on examples/main.tf] --> B{Root required_providers?}
    B -- "Before: aws ~> 5.0" --> C[Resolve aws provider]
    C --> D[modules/quilt ref=1.3.0\nrequires vpc ~> 6.0]
    D --> E[vpc ~> 6.0 requires\naws >= 6.28]
    E --> F["❌ CONFLICT\naws ~> 5.0 ∩ aws >= 6.28 = ∅\nterraform init fails"]
    B -- "After: no root pin" --> G[modules/quilt ref=1.7.2\nrequires vpc ~> 6.0]
    G --> H[vpc ~> 6.0 requires\naws >= 6.28]
    H --> I["✅ Resolves to\naws v6.49.0\nterraform init succeeds"]
```

<sub>Reviews (2): Last reviewed commit: ["Drop the root aws provider pin from the ..."](https://github.com/quiltdata/iac/commit/5cf896e588c73c2033e943f91af3038314f3d64b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36227575)</sub>

<!-- /greptile_comment -->