### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.8.0] - 2026-06-09
+
 - [Added] Transit Gateway egress mode for new VPCs: set `enable_transit_gateway = true` (+ `transit_gateway_id`) to route private-subnet egress through a Transit Gateway instead of NAT gateways; IPv6 egress is opt-in via `transit_gateway_ipv6_egress`. See [Transit Gateway egress](README.md#transit-gateway-egress) ([#115](https://github.com/quiltdata/iac/pull/115))
 
 ## [1.7.2] - 2026-06-08
@@ -100,7 +102,8 @@ Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading 
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))
 
-[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.2...HEAD
+[Unreleased]: https://github.com/quiltdata/iac/compare/1.8.0...HEAD
+[1.8.0]: https://github.com/quiltdata/iac/releases/tag/1.8.0
 [1.7.2]: https://github.com/quiltdata/iac/releases/tag/1.7.2
 [1.7.1]: https://github.com/quiltdata/iac/releases/tag/1.7.1
 [1.7.0]: https://github.com/quiltdata/iac/releases/tag/1.7.0


### PR DESCRIPTION
Cuts **1.8.0**, releasing the Transit Gateway egress mode (#115).

CHANGELOG-only: adds `## [1.8.0]` under `[Unreleased]` (the TGW `[Added]` entry becomes 1.8.0) and updates the link refs. Minor bump — the feature is opt-in and non-breaking (new vars default to off/null; existing deployments see no plan diff).

**Stacked on #115.** Base is `tgw-egress-toggle` so this captures the TGW changelog entry. Do **not** merge before #115 — once #115 merges and its branch is deleted, GitHub auto-retargets this PR's base to `main`, leaving a clean CHANGELOG-only release PR to merge + tag `1.8.0`.

Set the `[1.8.0]` date to the actual merge date before merging (currently a placeholder).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cuts the `1.8.0` release by promoting the Transit Gateway egress changelog entry from `[Unreleased]` into a new `## [1.8.0]` section and updating the comparison link refs accordingly.

- Adds `## [1.8.0] - 2026-06-09` with the TGW egress entry (moved from `[Unreleased]`); `[Unreleased]` is left empty for future work as expected.
- Updates `[Unreleased]` compare link from `1.7.2...HEAD` to `1.8.0...HEAD` and adds a `[1.8.0]` tag URL, matching the existing link-ref convention.

<h3>Confidence Score: 4/5</h3>

CHANGELOG-only change; all structural edits (section header, link refs) are correct and consistent with existing entries. The only thing to verify before merging is that the release date matches the actual merge day.

The change is mechanical and low-risk — it promotes one changelog entry and updates two link refs. The sole open item is the date `2026-06-09`, which the author themselves flagged as a placeholder; if the PR merges on a different day the recorded release date will be off.

No files require special attention beyond confirming the release date in `CHANGELOG.md` is updated to the actual merge date.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds `## [1.8.0] - 2026-06-09` section with the TGW egress entry (moved from `[Unreleased]`), updates the `[Unreleased]` compare link to `1.8.0...HEAD`, and adds a `[1.8.0]` tag link ref. Structure and link format match existing entries. Date is currently today's value but the PR description flags it as a placeholder that must be set to actual merge date. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["[Unreleased] - YYYY-MM-DD\n(empty, ready for next changes)"]
    B["[1.8.0] - 2026-06-09\nTransit Gateway egress mode"]
    C["[1.7.2] - 2026-06-08\nAWS provider constraint bump"]
    D["[1.7.1] and earlier..."]

    A --> B --> C --> D

    style A fill:#f9f,stroke:#999
    style B fill:#9cf,stroke:#36a,color:#000
```

<sub>Reviews (1): Last reviewed commit: ["Release 1.8.0"](https://github.com/quiltdata/iac/commit/b2eaa7a944263fb975cde362425df59f74735217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36458422)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->