### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+## [1.8.0] - 2026-06-09
+
 - [Added] Transit Gateway egress mode for new VPCs: set `enable_transit_gateway = true` (+ `transit_gateway_id`) to route private-subnet egress through a Transit Gateway instead of NAT gateways; IPv6 egress is opt-in via `transit_gateway_ipv6_egress`. See [Transit Gateway egress](README.md#transit-gateway-egress) ([#115](https://github.com/quiltdata/iac/pull/115))
 
 ## [1.7.2] - 2026-06-08
@@ -100,7 +102,8 @@ Ensure your Quilt stack is upgraded to version 1.66 or later *before* upgrading 
 
 - [Added] Add changelog ([#74](https://github.com/quiltdata/iac/pull/74))
 
-[Unreleased]: https://github.com/quiltdata/iac/compare/1.7.2...HEAD
+[Unreleased]: https://github.com/quiltdata/iac/compare/1.8.0...HEAD
+[1.8.0]: https://github.com/quiltdata/iac/releases/tag/1.8.0
 [1.7.2]: https://github.com/quiltdata/iac/releases/tag/1.7.2
 [1.7.1]: https://github.com/quiltdata/iac/releases/tag/1.7.1
 [1.7.0]: https://github.com/quiltdata/iac/releases/tag/1.7.0


### PR DESCRIPTION
Cut release 1.8.0 — adds the Transit Gateway egress mode merged in #115.

CHANGELOG-only: promotes the TGW entry from `[Unreleased]` into a dated `## [1.8.0]` section and updates the bottom link refs (`[Unreleased]` compare base → `1.8.0`, new `[1.8.0]` tag link). Matches the established release-PR convention (e.g. #118 for 1.7.2).

1.8.0 is a minor, non-breaking bump (new opt-in `enable_transit_gateway` feature; default behavior unchanged). After merge, tag `1.8.0` on the merge commit so the changelog links resolve.

Set the `[1.8.0]` date to the actual merge date before merging if it slips past 2026-06-09.

---
Supersedes #120, which was auto-closed when #115's branch was deleted with `--delete-branch` (a known GitHub bug closes stacked dependents instead of retargeting them). This branch is freshly based on `main` post-merge, so no stacked-history conflict.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a CHANGELOG-only release cut for 1.8.0, moving the Transit Gateway egress entry from `[Unreleased]` into a dated `## [1.8.0]` section and updating the bottom link references to point `[Unreleased]` at `1.8.0...HEAD` while adding the new `[1.8.0]` tag link.

- The `[Unreleased]` placeholder is correctly left empty above `[1.8.0]`, ready for the next cycle.
- The `[Unreleased]` compare base and the new `[1.8.0]` release tag link both reference `1.8.0`, matching the established convention from prior release PRs (e.g. `1.7.2`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is CHANGELOG-only and follows the established release-cut convention exactly.

Only CHANGELOG.md is touched. The section structure, link-ref update, and empty [Unreleased] placeholder are all consistent with prior release PRs. The date matches today and the TGW bullet content matches the underlying #115 feature PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Promotes the TGW entry from [Unreleased] into a dated [1.8.0] section and updates the bottom link refs; empty [Unreleased] placeholder retained for future changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["[Unreleased] - YYYY-MM-DD\n(empty placeholder)"] --> B["[1.8.0] - 2026-06-09\n+ TGW egress entry"]
    B --> C["[1.7.2] - 2026-06-08\n..."]
    D["Link refs"] --> E["[Unreleased]: compare/1.8.0...HEAD"]
    D --> F["[1.8.0]: releases/tag/1.8.0  ← new"]
    D --> G["[1.7.2]: releases/tag/1.7.2"]
```

<sub>Reviews (1): Last reviewed commit: ["Release 1.8.0"](https://github.com/quiltdata/iac/commit/579b98d5147d3254ffed975258378fb36e1fa38e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36462663)</sub>

<!-- /greptile_comment -->