### PR TITLE
Add Ravion (IDP) module definition for modules/quilt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .terraform.lock.hcl
 tfplan
 node_modules
+examples/ravion/.quilt-template-*.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Optional release notice.
 
 ## [Unreleased] - YYYY-MM-DD
 
+- [Added] `examples/ravion/` — a Ravion (IDP) module definition wrapping `modules/quilt`/`modules/cnames` unmodified, with typed `$ref` composition for certificate + DNS and derived catalog/registry/s3-proxy hostname coverage. See [examples/ravion/README.md](examples/ravion/README.md) ([#126](https://github.com/quiltdata/iac/issues/126))
+
 ## [1.8.0] - 2026-06-09
 
 - [Added] Transit Gateway egress mode for new VPCs: set `enable_transit_gateway = true` (+ `transit_gateway_id`) to route private-subnet egress through a Transit Gateway instead of NAT gateways; IPv6 egress is opt-in via `transit_gateway_ipv6_egress`. See [Transit Gateway egress](README.md#transit-gateway-egress) ([#115](https://github.com/quiltdata/iac/pull/115))

--- a/examples/ravion/README.md
+++ b/examples/ravion/README.md
@@ -1,0 +1,76 @@
+# Deploying `modules/quilt` via Ravion
+
+[Ravion](https://www.ravion.com) is an Internal Developer Platform (IDP) that
+runs Terraform/OpenTofu on temporary runners inside a connected AWS account,
+and exposes infrastructure as typed, form-fillable modules.
+
+This directory demonstrates deploying Quilt through Ravion **without forking
+any Terraform**: [`module.yaml`](module.yaml) is a Ravion module definition
+that wraps [`main.tf`](main.tf), which in turn calls `modules/quilt` and
+`modules/cnames` from this repo unmodified, using the same
+`provider` / `module "quilt"` / `parameters` root-config pattern documented
+in [`examples/main.tf`](../main.tf).
+
+## How the pieces fit together
+
+- **`module.yaml`** declares the handful of typed inputs a deploy actually
+  needs (name, catalog domain, sizing, network mode, admin email) instead of
+  raw HCL, plus two `$ref` inputs — `certificate_ref` and `dns_ref` — that
+  Ravion resolves against other Ravion-managed modules rather than requiring
+  a hand-copied certificate ARN or hosted-zone ID.
+- **`main.tf`** receives those resolved values as plain Terraform variables
+  (`certificate_arn`, `zone_id`, …) and calls `modules/quilt` /
+  `modules/cnames` exactly as a manual deploy would.
+- **The CloudFormation template is never committed here.** `module.yaml`'s
+  `template_url` input points at the template for the desired Quilt release
+  (e.g. one of this project's existing published per-release S3 artifacts);
+  Ravion fetches it at plan/apply time and hands the resulting local path to
+  `template_file`. Nothing generated or internal is checked into this repo.
+
+## Hostname / certificate coverage
+
+Quilt's public hostname contract is the catalog host plus two derived
+siblings:
+
+- `<catalog_domain>` — the catalog itself
+- `<sub>-registry.<rest>` — the registry API
+- `<sub>-s3-proxy.<rest>` — the S3 proxy
+
+`main.tf` derives all three into `local.hostnames` (and exposes them as the
+`hostnames` output). Ravion should validate that the certificate resolved
+via `certificate_ref` covers all three SANs before allowing `apply` — a
+certificate that only covers the catalog host will deploy a stack whose
+registry or s3-proxy endpoint has no valid TLS.
+
+## Cross-account composition (certificate + stack + DNS)
+
+The common case for larger customers is that the AWS account deploying the
+stack does **not** own the domain. In that setup:
+
+- The **certificate** module (ACM, DNS-validated) runs in the account that
+  owns the Route53 zone.
+- The **DNS** module (`modules/cnames`) also runs in that same
+  domain-owning account, since it writes into the hosted zone.
+- The **Quilt stack** (`module.yaml` / `main.tf` in this directory) runs in
+  the deploying account, and references the certificate and DNS modules via
+  `certificate_ref` / `dns_ref`.
+
+Ravion's typed `$ref` module-composition mechanism resolves outputs across
+these Ravion-connected accounts, so the certificate ARN and CNAME records
+are wired in automatically rather than hand-copied between teams. This is a
+supported Ravion pattern, not a workaround — call it out explicitly when
+onboarding a customer whose deploying and domain-owning accounts differ.
+
+## In-place updates
+
+Changing a typed input in Ravion (e.g. `sizing`, `catalog_domain`) re-plans
+and re-applies the same `module "quilt"` / `module "cnames"` resources in
+place, the same as re-running `terraform apply` with an edited
+`examples/main.tf` — no destroy/recreate.
+
+## Relationship to `examples/main.tf`
+
+This is a Ravion-specific wrapper, not a replacement for the manual example
+in [`examples/main.tf`](../main.tf). Use `examples/main.tf` for a standalone
+`terraform apply`; use this directory as the module definition when
+onboarding this repo into a Ravion catalog.

--- a/examples/ravion/README.md
+++ b/examples/ravion/README.md
@@ -61,6 +61,17 @@ are wired in automatically rather than hand-copied between teams. This is a
 supported Ravion pattern, not a workaround — call it out explicitly when
 onboarding a customer whose deploying and domain-owning accounts differ.
 
+## Provisioning script
+
+[`scripts/provision-quilt.sh`](scripts/provision-quilt.sh) wraps the three
+`ravion module create` calls needed to stand up a deployment — the
+`rvn-route53` reference, the `rvn-acm-certificate` covering all three derived
+hostnames, and the `quilt-catalog` instance that `$ref`s both — into one
+command, threading the `minst_…` instance ids between them so nobody has to
+hand-copy them. Run it with `--dry-run` first to see the exact commands it
+would issue; `--dns-instance-id` / `--cert-instance-id` let you reuse
+already-applied instances instead of creating new ones.
+
 ## In-place updates
 
 Changing a typed input in Ravion (e.g. `sizing`, `catalog_domain`) re-plans

--- a/examples/ravion/main.tf
+++ b/examples/ravion/main.tf
@@ -1,7 +1,7 @@
 # Example root config for the Ravion module definition (module.yaml) in this
 # directory. Ravion renders module.yaml's typed inputs into the variables
 # below and supplies certificate_arn / zone_id / lb_dns_name by resolving
-# certificate_ref / dns_ref against the modules those refs point to — which
+# the certificate / dns refs against the modules those refs point to — which
 # may live in a different Ravion-connected AWS account than this one (see
 # README.md).
 #
@@ -9,6 +9,10 @@
 
 terraform {
   required_version = ">= 1.10.0"
+  required_providers {
+    http  = { source = "hashicorp/http" }
+    local = { source = "hashicorp/local" }
+  }
 }
 
 variable "name" {
@@ -19,6 +23,20 @@ variable "name" {
 variable "template_url" {
   type        = string
   description = "URL of the published Quilt CloudFormation template. Fetched at apply time; never committed."
+}
+
+# modules/quilt's template_file input takes a local path — it's uploaded to
+# a per-install S3 bucket and hashed via filemd5() — so template_url has to
+# be fetched and written to a local file before it reaches module "quilt"
+# below; passing the URL straight through fails filemd5() on a URL string.
+data "http" "template" {
+  url = var.template_url
+}
+
+resource "local_file" "template" {
+  filename        = "${path.module}/.quilt-template-${md5(var.template_url)}.yaml"
+  content         = data.http.template.response_body
+  file_permission = "0600"
 }
 
 variable "catalog_domain" {
@@ -46,25 +64,25 @@ variable "create_new_vpc" {
   default = true
 }
 
-# Supplied by Ravion when create_new_vpc = false, resolved from vpc_ref.
+# Supplied by Ravion when create_new_vpc = false, resolved from the vpc ref.
 variable "vpc_id" {
   type    = string
   default = null
 }
 
-# Supplied by Ravion, resolved from certificate_ref. Ravion is responsible
+# Supplied by Ravion, resolved from the certificate ref. Ravion is responsible
 # for confirming the certificate's SANs cover all of local.hostnames before
 # this config ever runs.
 variable "certificate_arn" {
   type        = string
-  description = "ACM certificate ARN, resolved by Ravion from certificate_ref."
+  description = "ACM certificate ARN, resolved by Ravion from the certificate ref."
 }
 
-# Supplied by Ravion, resolved from dns_ref. May belong to a different
+# Supplied by Ravion, resolved from the dns ref. May belong to a different
 # AWS account than the one this stack deploys into.
 variable "zone_id" {
   type        = string
-  description = "Route53 hosted zone ID, resolved by Ravion from dns_ref."
+  description = "Route53 hosted zone ID, resolved by Ravion from the dns ref."
 }
 
 locals {
@@ -121,7 +139,7 @@ module "quilt" {
   source = "github.com/quiltdata/iac//modules/quilt?ref=1.8.0"
 
   name          = var.name
-  template_file = var.template_url
+  template_file = local_file.template.filename
 
   internal       = var.internal
   create_new_vpc = var.create_new_vpc

--- a/examples/ravion/main.tf
+++ b/examples/ravion/main.tf
@@ -1,0 +1,182 @@
+# Example root config for the Ravion module definition (module.yaml) in this
+# directory. Ravion renders module.yaml's typed inputs into the variables
+# below and supplies certificate_arn / zone_id / lb_dns_name by resolving
+# certificate_ref / dns_ref against the modules those refs point to — which
+# may live in a different Ravion-connected AWS account than this one (see
+# README.md).
+#
+# modules/quilt and modules/cnames are used completely unmodified.
+
+terraform {
+  required_version = ">= 1.10.0"
+}
+
+variable "name" {
+  type        = string
+  description = "Stack name (<=20 chars, lowercase alphanumeric + hyphens)."
+}
+
+variable "template_url" {
+  type        = string
+  description = "URL of the published Quilt CloudFormation template. Fetched at apply time; never committed."
+}
+
+variable "catalog_domain" {
+  type        = string
+  description = "Public hostname for the Quilt catalog."
+}
+
+variable "admin_email" {
+  type        = string
+  description = "Initial admin account email address."
+}
+
+variable "sizing" {
+  type    = string
+  default = "medium"
+}
+
+variable "internal" {
+  type    = bool
+  default = false
+}
+
+variable "create_new_vpc" {
+  type    = bool
+  default = true
+}
+
+# Supplied by Ravion when create_new_vpc = false, resolved from vpc_ref.
+variable "vpc_id" {
+  type    = string
+  default = null
+}
+
+# Supplied by Ravion, resolved from certificate_ref. Ravion is responsible
+# for confirming the certificate's SANs cover all of local.hostnames before
+# this config ever runs.
+variable "certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN, resolved by Ravion from certificate_ref."
+}
+
+# Supplied by Ravion, resolved from dns_ref. May belong to a different
+# AWS account than the one this stack deploys into.
+variable "zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID, resolved by Ravion from dns_ref."
+}
+
+locals {
+  # Quilt's hostname contract: the catalog host plus its derived registry
+  # and s3-proxy siblings. The referenced certificate must cover all three.
+  match     = regex("^([^.]+)(\\..*)$", var.catalog_domain)
+  subdomain = local.match[0]
+  remainder = local.match[1]
+  hostnames = [
+    var.catalog_domain,
+    "${local.subdomain}-registry${local.remainder}",
+    "${local.subdomain}-s3-proxy${local.remainder}",
+  ]
+
+  sizing_profiles = {
+    small = {
+      search_dedicated_master_enabled = false
+      search_zone_awareness_enabled   = false
+      search_instance_count           = 1
+      search_instance_type            = "m6g.large.elasticsearch"
+      search_volume_size              = 512
+      db_instance_class               = "db.t3.small"
+    }
+    medium = {
+      search_dedicated_master_enabled = true
+      search_zone_awareness_enabled   = true
+      search_instance_count           = 2
+      search_instance_type            = "m6g.xlarge.elasticsearch"
+      search_volume_size              = 1024
+      db_instance_class               = "db.t3.medium"
+    }
+    large = {
+      search_dedicated_master_enabled = true
+      search_zone_awareness_enabled   = true
+      search_instance_count           = 2
+      search_instance_type            = "m6g.xlarge.elasticsearch"
+      search_volume_size              = 2048
+      db_instance_class               = "db.r6g.large"
+    }
+    xlarge = {
+      search_dedicated_master_enabled = true
+      search_zone_awareness_enabled   = true
+      search_instance_count           = 2
+      search_instance_type            = "m6g.2xlarge.elasticsearch"
+      search_volume_size              = 3072
+      db_instance_class               = "db.r6g.xlarge"
+    }
+  }
+
+  profile = local.sizing_profiles[var.sizing]
+}
+
+module "quilt" {
+  source = "github.com/quiltdata/iac//modules/quilt?ref=1.8.0"
+
+  name          = var.name
+  template_file = var.template_url
+
+  internal       = var.internal
+  create_new_vpc = var.create_new_vpc
+  cidr           = "10.0.0.0/16"
+  vpc_id         = var.create_new_vpc ? null : var.vpc_id
+
+  db_instance_class      = local.profile.db_instance_class
+  db_multi_az            = true
+  db_deletion_protection = true
+
+  search_dedicated_master_enabled = local.profile.search_dedicated_master_enabled
+  search_zone_awareness_enabled   = local.profile.search_zone_awareness_enabled
+  search_instance_count           = local.profile.search_instance_count
+  search_instance_type            = local.profile.search_instance_type
+  search_volume_size              = local.profile.search_volume_size
+  search_volume_type              = "gp3"
+
+  parameters = {
+    AdminEmail        = var.admin_email
+    CertificateArnELB = var.certificate_arn
+    QuiltWebHost      = var.catalog_domain
+    PasswordAuth      = "Enabled"
+  }
+}
+
+# DNS: creates the catalog + registry + s3-proxy CNAMEs once the stack's
+# load balancer DNS name is known. zone_id may come from a different
+# Ravion-connected account than the one hosting module.quilt — see README.
+module "cnames" {
+  source = "github.com/quiltdata/iac//modules/cnames?ref=1.8.0"
+
+  lb_dns_name    = module.quilt.stack.outputs.LoadBalancerDNSName
+  quilt_web_host = var.catalog_domain
+  zone_id        = var.zone_id
+}
+
+output "hostnames" {
+  description = "Hostnames the referenced certificate must cover."
+  value       = local.hostnames
+}
+
+output "admin_password" {
+  sensitive = true
+  value     = module.quilt.admin_password
+}
+
+output "db_password" {
+  sensitive = true
+  value     = module.quilt.db_password
+}
+
+output "quilt_url" {
+  value = "https://${var.catalog_domain}"
+}
+
+output "load_balancer_dns" {
+  value = module.quilt.stack.outputs.LoadBalancerDNSName
+}

--- a/examples/ravion/module.yaml
+++ b/examples/ravion/module.yaml
@@ -5,107 +5,195 @@
 # standard root-config pattern (`provider`, `module "quilt"`, `parameters`)
 # through a typed, form-fillable interface.
 #
-# Field names/types follow Ravion's module-definition conventions as of the
-# evaluation referenced in issue #126. Validate against the current Ravion
-# module-schema docs before publishing to a Ravion catalog, since the schema
-# is owned by Ravion, not this repo.
-
-name: quilt
-description: >-
-  Deploy the Quilt data platform (catalog, registry, search, and supporting
-  infrastructure) into a connected AWS account via CloudFormation.
-version: "1.0.0"
-
-# Root config this module definition drives. Pinned to a released tag of
-# this repo; unmodified from modules/quilt's own interface.
-source:
-  repo: github.com/quiltdata/iac
-  path: examples/ravion
-  ref: "1.8.0"
-
-# The CloudFormation template is fetched at plan/apply time from this
-# project's existing published per-release S3 artifact — never committed
-# here. `template_url` is resolved to a local path and handed to
-# modules/quilt's `template_file` input.
-template:
-  fetch: url
-  url_input: template_url
+# Shape verified against a live Ravion org (v0.2.11, 2026-07-28): this file's
+# structure — `inputs` as an array, `$ref:<type>` syntax, `mapped_inputs` for
+# pulling a referenced module's outputs, no top-level `outputs` key — was
+# registered via `ravion module definition create` + `ravion module version
+# create --config <this file, converted to JSON>` and schema-rendered
+# successfully. See ../../../09-blog-deploying-quilt-via-ravion.md in the
+# 260723-ravion evaluation project for the exact commands and the wrong
+# shape this replaces (a `name`/`source`/`template`/flat-map-`inputs`/
+# `outputs` DSL that doesn't correspond to any real Ravion schema key).
+#
+# `name` (module definition name), `type` (module type identifier, e.g.
+# `quilt-catalog`), `version`, and `description` are NOT config keys — they
+# are supplied as flags to `ravion module definition create` / `ravion
+# module version create`, not fields in this file. The `source.ref` /
+# `template.*` keys from the previous draft don't exist in Ravion's schema
+# either: which release of `modules/quilt` this wraps is pinned by the
+# `branch`/`base_path` a definition's `stack.pipelines.defaults.input` points
+# at (see below), and the CloudFormation template is fetched from
+# `template_url` inside `main.tf` itself (a `data "http"` + `local_file`
+# pair — `modules/quilt`'s `template_file` input requires a local path, not
+# a URL, since it's uploaded to S3 via `filemd5()`).
 
 inputs:
-  name:
+  - id: name
     type: string
+    label: Stack name
     description: Stack name (<=20 chars, lowercase alphanumeric + hyphens).
     required: true
 
-  template_url:
+  - id: template_url
     type: string
+    label: CloudFormation template URL
     description: >-
       URL of the published Quilt CloudFormation template for the desired
       release (e.g. an S3 artifact URL from this project's release process).
+      Fetched at plan/apply time and written to a local path — see main.tf.
     required: true
 
-  catalog_domain:
+  - id: catalog_domain
     type: string
+    label: Catalog domain
     description: >-
       Public hostname for the Quilt catalog (e.g. data.example.com). The
       registry and s3-proxy hostnames are derived from this value as
-      `<sub>-registry.<rest>` and `<sub>-s3-proxy.<rest>`.
+      `<sub>-registry.<rest>` and `<sub>-s3-proxy.<rest>`. A certificate
+      covering only this host is not enough — see the `certificate` ref
+      below.
     required: true
 
-  admin_email:
+  - id: admin_email
     type: string
+    label: Admin email
     description: Initial admin account email address.
     required: true
 
-  sizing:
+  - id: sizing
     type: string
+    label: Sizing
     description: Named ElasticSearch/DB sizing profile.
-    enum: [small, medium, large, xlarge]
     default: medium
+    values:
+      - label: Small
+        value: small
+      - label: Medium
+        value: medium
+      - label: Large
+        value: large
+      - label: X-Large
+        value: xlarge
 
-  internal:
-    type: bool
+  - id: internal
+    type: boolean
+    label: Internal (VPN-only) load balancer
     description: If true, deploy an internal (VPN-only) load balancer.
     default: false
 
-  create_new_vpc:
-    type: bool
-    description: If true, provision a new VPC; if false, use vpc_ref.
+  - id: create_new_vpc
+    type: boolean
+    label: Create new VPC
+    description: If true, provision a new VPC; if false, use the vpc reference.
     default: true
 
-  vpc_ref:
-    type: ref
+  - id: aws_account_id
+    type: string
+    label: AWS Account
+    description: Account the Quilt stack is deployed into.
+    required: true
+    values: "$values:ravion/aws_accounts"
+
+  - id: aws_region
+    type: string
+    label: Region
+    required: true
+    values: "$values:aws/regions"
+
+  - id: execution_environment_id
+    type: string
+    label: Execution environment
+    description: >-
+      Overrides the environment's default execution environment for the
+      Terraform runner. Optional.
+    values: "$values:ravion/execution_environments"
+
+  # Typed references — Ravion resolves these against another module
+  # instance's outputs (in the same or a different connected AWS account)
+  # instead of a hand-copied ARN/zone ID. A ref's outputs are only reachable
+  # through its own `mapped_inputs` list (`<< ref.stack.output.x >>` there);
+  # referencing `ref.*` anywhere else in this file is rejected by the API.
+  - id: certificate
+    type: "$ref:rvn-acm-certificate"
+    label: TLS certificate
+    description: >-
+      Reference to a Ravion-managed ACM certificate module. The certificate
+      MUST cover all three derived hostnames (catalog, registry, s3-proxy) —
+      set that certificate module's own `domains` input to all three; this
+      definition cannot derive them into a sibling module for you.
+    required: true
+    mapped_inputs:
+      - id: certificate_arn
+        label: Certificate ARN
+        type: string
+        default: "<< ref.stack.output.certificate_arn >>"
+
+  - id: dns
+    type: "$ref:rvn-route53"
+    label: DNS hosted zone
+    description: >-
+      Reference to a Ravion-managed Route 53 module that will receive the
+      catalog/registry/s3-proxy records once the stack's load balancer DNS
+      name is known. May live in a different connected AWS account than
+      this module (the common case when the deploying account doesn't own
+      the domain) — see README.md.
+    required: true
+    mapped_inputs:
+      - id: zone_id
+        label: Zone ID
+        type: string
+        default: "<< ref.stack.output.zone_id >>"
+
+  # Optional: bring your own VPC instead of create_new_vpc. NOTE: the
+  # rvn-aws-network output field name below (`vpc_id`) is a best-guess by
+  # convention, not independently verified the way certificate_arn/zone_id
+  # were (those were confirmed live against applied rvn-acm-certificate /
+  # rvn-route53 instances in the 260723-ravion eval; no rvn-aws-network
+  # instance was ever applied in that eval to check against). Confirm
+  # against `ravion module schema rvn-aws-network`'s outputs before relying
+  # on this in production.
+  - id: vpc
+    type: "$ref:rvn-aws-network"
+    label: Existing VPC
     description: >-
       Reference to a Ravion-managed VPC module. Required when
       create_new_vpc is false; ignored otherwise.
     required: false
+    mapped_inputs:
+      - id: vpc_id
+        label: VPC ID
+        type: string
+        default: "<< ref.stack.output.vpc_id >>"
 
-  # Typed references — Ravion resolves these to outputs from other modules
-  # (in the same or a different connected AWS account) instead of requiring
-  # a hand-copied ARN/zone ID.
-  certificate_ref:
-    type: ref
-    description: >-
-      Reference to a Ravion-managed ACM certificate module. The certificate
-      MUST cover all three derived hostnames (catalog, registry, s3-proxy);
-      Ravion should validate SAN coverage against the derived hostname list
-      before allowing apply.
-    required: true
+# No top-level `outputs` key — Terraform outputs (quilt_url,
+# load_balancer_dns, admin_password, db_password) are exposed automatically
+# as `stack.output.*` once main.tf declares them as `output "..."` blocks.
 
-  dns_ref:
-    type: ref
-    description: >-
-      Reference to a Ravion-managed DNS/hosted-zone module (modules/cnames
-      or equivalent) that will receive the catalog/registry/s3-proxy CNAME
-      records once the stack's load balancer DNS name is known. May live in
-      a different connected AWS account than this module (the common case
-      when the deploying account doesn't own the domain) — see README.md.
-    required: true
-
-outputs:
-  admin_password:
-    sensitive: true
-  db_password:
-    sensitive: true
-  quilt_url: {}
-  load_balancer_dns: {}
+stack:
+  type: opentofu
+  pipelines:
+    defaults:
+      variant: standard
+      input:
+        repo: "https://github.com/quiltdata/iac.git"
+        branch: "add-ravion-support-126" # pin to a released tag before publishing, e.g. "1.8.0"
+        base_path: examples/ravion
+        aws_account_id: "<< module.input.aws_account_id >>"
+        aws_region: "<< module.input.aws_region >>"
+        execution_environment_id: "<< module.input.execution_environment_id || defaults.execution_environment_id >>"
+        tool: opentofu
+        terraform_variables:
+          name: "<< module.input.name >>"
+          template_url: "<< module.input.template_url >>"
+          catalog_domain: "<< module.input.catalog_domain >>"
+          admin_email: "<< module.input.admin_email >>"
+          sizing: "<< module.input.sizing >>"
+          internal: "<< module.input.internal >>"
+          create_new_vpc: "<< module.input.create_new_vpc >>"
+          vpc_id: "<< module.input.vpc_id >>"
+          certificate_arn: "<< module.input.certificate_arn >>"
+          zone_id: "<< module.input.zone_id >>"
+    change:
+      pipeline_id: "<< defaults.change_pipeline_id >>"
+    destroy:
+      pipeline_id: "<< defaults.destroy_pipeline_id >>"

--- a/examples/ravion/module.yaml
+++ b/examples/ravion/module.yaml
@@ -1,0 +1,111 @@
+# Ravion module definition for `modules/quilt`.
+#
+# This wraps modules/quilt (and modules/cnames) from this repo UNMODIFIED —
+# no forked Terraform, no vendored CloudFormation template. Ravion drives the
+# standard root-config pattern (`provider`, `module "quilt"`, `parameters`)
+# through a typed, form-fillable interface.
+#
+# Field names/types follow Ravion's module-definition conventions as of the
+# evaluation referenced in issue #126. Validate against the current Ravion
+# module-schema docs before publishing to a Ravion catalog, since the schema
+# is owned by Ravion, not this repo.
+
+name: quilt
+description: >-
+  Deploy the Quilt data platform (catalog, registry, search, and supporting
+  infrastructure) into a connected AWS account via CloudFormation.
+version: "1.0.0"
+
+# Root config this module definition drives. Pinned to a released tag of
+# this repo; unmodified from modules/quilt's own interface.
+source:
+  repo: github.com/quiltdata/iac
+  path: examples/ravion
+  ref: "1.8.0"
+
+# The CloudFormation template is fetched at plan/apply time from this
+# project's existing published per-release S3 artifact — never committed
+# here. `template_url` is resolved to a local path and handed to
+# modules/quilt's `template_file` input.
+template:
+  fetch: url
+  url_input: template_url
+
+inputs:
+  name:
+    type: string
+    description: Stack name (<=20 chars, lowercase alphanumeric + hyphens).
+    required: true
+
+  template_url:
+    type: string
+    description: >-
+      URL of the published Quilt CloudFormation template for the desired
+      release (e.g. an S3 artifact URL from this project's release process).
+    required: true
+
+  catalog_domain:
+    type: string
+    description: >-
+      Public hostname for the Quilt catalog (e.g. data.example.com). The
+      registry and s3-proxy hostnames are derived from this value as
+      `<sub>-registry.<rest>` and `<sub>-s3-proxy.<rest>`.
+    required: true
+
+  admin_email:
+    type: string
+    description: Initial admin account email address.
+    required: true
+
+  sizing:
+    type: string
+    description: Named ElasticSearch/DB sizing profile.
+    enum: [small, medium, large, xlarge]
+    default: medium
+
+  internal:
+    type: bool
+    description: If true, deploy an internal (VPN-only) load balancer.
+    default: false
+
+  create_new_vpc:
+    type: bool
+    description: If true, provision a new VPC; if false, use vpc_ref.
+    default: true
+
+  vpc_ref:
+    type: ref
+    description: >-
+      Reference to a Ravion-managed VPC module. Required when
+      create_new_vpc is false; ignored otherwise.
+    required: false
+
+  # Typed references — Ravion resolves these to outputs from other modules
+  # (in the same or a different connected AWS account) instead of requiring
+  # a hand-copied ARN/zone ID.
+  certificate_ref:
+    type: ref
+    description: >-
+      Reference to a Ravion-managed ACM certificate module. The certificate
+      MUST cover all three derived hostnames (catalog, registry, s3-proxy);
+      Ravion should validate SAN coverage against the derived hostname list
+      before allowing apply.
+    required: true
+
+  dns_ref:
+    type: ref
+    description: >-
+      Reference to a Ravion-managed DNS/hosted-zone module (modules/cnames
+      or equivalent) that will receive the catalog/registry/s3-proxy CNAME
+      records once the stack's load balancer DNS name is known. May live in
+      a different connected AWS account than this module (the common case
+      when the deploying account doesn't own the domain) — see README.md.
+    required: true
+
+outputs:
+  admin_password:
+    sensitive: true
+  db_password:
+    sensitive: true
+  quilt_url: {}
+  load_balancer_dns: {}

--- a/examples/ravion/scripts/provision-quilt.sh
+++ b/examples/ravion/scripts/provision-quilt.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# Provisions a Quilt deployment through Ravion end to end: the Route 53 DNS
+# reference, the multi-SAN ACM certificate, and the quilt-catalog instance
+# that $refs both. See ../../../09-blog-deploying-quilt-via-ravion.md (Step 4
+# and Step 5) in the 260723-ravion evaluation project for the manual version
+# of these three `ravion module create` calls this replaces.
+#
+# Quilt's public hostname contract is the catalog host plus two derived
+# siblings (<sub>-registry.<rest> / <sub>-s3-proxy.<rest>>) — see main.tf's
+# `local.hostnames`. This script computes all three the same way and passes
+# them to rvn-acm-certificate's `domains` input, so the cert can't
+# accidentally cover only the catalog host.
+#
+# Requires: the `ravion` CLI (authenticated) and `jq`.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: provision-quilt.sh [options]
+
+Required:
+  --catalog-domain DOMAIN        Public catalog hostname, e.g. quilt.customer.com
+  --name NAME                    Stack name (<=20 chars, lowercase alphanumeric + hyphens)
+  --template-url URL             Published Quilt CloudFormation template URL
+  --admin-email EMAIL            Initial admin account email
+
+  --dns-environment-id ID         env_… for the domain-owning environment
+  --dns-account-id ID             awsact_… that owns the Route53 zone
+  --zone-id ID                    Existing Route53 hosted zone ID (e.g. Z1234567890ABC)
+
+  --cert-account-id ID            awsact_… for the ALB/deploying account (ACM cert must
+                                   live in the same account/region as the load balancer)
+
+  --quilt-environment-id ID       env_… for the deploying environment
+  --quilt-account-id ID           awsact_… the Quilt stack deploys into
+
+Optional:
+  --given-id-prefix PREFIX        Prefix for module given-ids (default: quilt)
+  --dns-region REGION             Default: us-east-1
+  --cert-environment-id ID        Default: same as --dns-environment-id
+  --cert-region REGION            Default: same as --dns-region
+  --quilt-region REGION           Default: us-east-1
+  --sizing SIZE                   small|medium|large|xlarge (default: medium)
+  --dns-instance-id ID            Reuse an existing rvn-route53 instance instead of
+                                   creating one (skips --dns-* / --zone-id)
+  --cert-instance-id ID           Reuse an existing rvn-acm-certificate instance instead
+                                   of creating one (skips --cert-* / --zone-id)
+  --dry-run                       Print the ravion commands instead of running them
+  -h, --help                      Show this help
+
+All three underlying `ravion module create` calls use --initial-stack-run
+APPLY, i.e. this creates and applies real infrastructure.
+EOF
+}
+
+given_id_prefix=quilt
+dns_region=us-east-1
+cert_region=
+quilt_region=us-east-1
+sizing=medium
+dns_instance_id=
+cert_instance_id=
+dry_run=0
+
+catalog_domain=
+name=
+template_url=
+admin_email=
+dns_environment_id=
+dns_account_id=
+zone_id=
+cert_environment_id=
+cert_account_id=
+quilt_environment_id=
+quilt_account_id=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --catalog-domain) catalog_domain="$2"; shift 2 ;;
+    --name) name="$2"; shift 2 ;;
+    --template-url) template_url="$2"; shift 2 ;;
+    --admin-email) admin_email="$2"; shift 2 ;;
+    --sizing) sizing="$2"; shift 2 ;;
+    --given-id-prefix) given_id_prefix="$2"; shift 2 ;;
+    --dns-environment-id) dns_environment_id="$2"; shift 2 ;;
+    --dns-account-id) dns_account_id="$2"; shift 2 ;;
+    --dns-region) dns_region="$2"; shift 2 ;;
+    --zone-id) zone_id="$2"; shift 2 ;;
+    --cert-environment-id) cert_environment_id="$2"; shift 2 ;;
+    --cert-account-id) cert_account_id="$2"; shift 2 ;;
+    --cert-region) cert_region="$2"; shift 2 ;;
+    --quilt-environment-id) quilt_environment_id="$2"; shift 2 ;;
+    --quilt-account-id) quilt_account_id="$2"; shift 2 ;;
+    --quilt-region) quilt_region="$2"; shift 2 ;;
+    --dns-instance-id) dns_instance_id="$2"; shift 2 ;;
+    --cert-instance-id) cert_instance_id="$2"; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+cert_environment_id="${cert_environment_id:-$dns_environment_id}"
+cert_region="${cert_region:-$dns_region}"
+
+for bin in ravion jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "Missing required tool: $bin" >&2; exit 1; }
+done
+
+missing=()
+[[ -n "$catalog_domain" ]] || missing+=(--catalog-domain)
+[[ -n "$name" ]] || missing+=(--name)
+[[ -n "$template_url" ]] || missing+=(--template-url)
+[[ -n "$admin_email" ]] || missing+=(--admin-email)
+[[ -n "$quilt_environment_id" ]] || missing+=(--quilt-environment-id)
+[[ -n "$quilt_account_id" ]] || missing+=(--quilt-account-id)
+if [[ -z "$dns_instance_id" ]]; then
+  [[ -n "$dns_environment_id" ]] || missing+=(--dns-environment-id)
+  [[ -n "$dns_account_id" ]] || missing+=(--dns-account-id)
+  [[ -n "$zone_id" ]] || missing+=(--zone-id)
+fi
+if [[ -z "$cert_instance_id" ]]; then
+  [[ -n "$cert_account_id" ]] || missing+=(--cert-account-id)
+  [[ -n "$zone_id" ]] || missing+=(--zone-id)
+fi
+if [[ ${#missing[@]} -gt 0 ]]; then
+  printf 'Missing required argument(s): %s\n\n' "${missing[*]}" >&2
+  usage >&2
+  exit 1
+fi
+
+# Same derivation as main.tf's local.hostnames: split on the first dot.
+if [[ ! "$catalog_domain" =~ ^([^.]+)(\..*)$ ]]; then
+  echo "--catalog-domain must be a hostname with at least one dot: $catalog_domain" >&2
+  exit 1
+fi
+subdomain="${BASH_REMATCH[1]}"
+remainder="${BASH_REMATCH[2]}"
+registry_host="${subdomain}-registry${remainder}"
+proxy_host="${subdomain}-s3-proxy${remainder}"
+
+echo "Derived hostnames: $catalog_domain, $registry_host, $proxy_host" >&2
+
+run_ravion_create() {
+  # $1=given-id $2=display name $3=type $4=environment-id $5=input JSON
+  if [[ $dry_run -eq 1 ]]; then
+    echo "--- dry run: ravion module create ---" >&2
+    printf 'ravion module create --environment-id %q --given-id %q --name %q --type %q --input %q --initial-stack-run APPLY --json\n' \
+      "$4" "$1" "$2" "$3" "$5" >&2
+    echo '{"id":"minst_dryrun"}'
+    return
+  fi
+  ravion module create \
+    --environment-id "$4" \
+    --given-id "$1" \
+    --name "$2" \
+    --type "$3" \
+    --input "$5" \
+    --initial-stack-run APPLY \
+    --json
+}
+
+if [[ -n "$dns_instance_id" ]]; then
+  echo "Reusing existing rvn-route53 instance: $dns_instance_id" >&2
+else
+  dns_input=$(jq -n \
+    --arg aws_account_id "$dns_account_id" \
+    --arg aws_region "$dns_region" \
+    --arg zone_id "$zone_id" \
+    '{aws_account_id: $aws_account_id, aws_region: $aws_region, zone_creation_enabled: false, zone_id: $zone_id}')
+
+  echo "Creating rvn-route53 instance..." >&2
+  dns_instance_id=$(run_ravion_create "${given_id_prefix}-dns" "Quilt DNS zone" rvn-route53 "$dns_environment_id" "$dns_input" | jq -r '.id')
+  echo "  -> $dns_instance_id" >&2
+fi
+
+if [[ -n "$cert_instance_id" ]]; then
+  echo "Reusing existing rvn-acm-certificate instance: $cert_instance_id" >&2
+else
+  cert_input=$(jq -n \
+    --arg aws_account_id "$cert_account_id" \
+    --arg aws_region "$cert_region" \
+    --arg catalog_domain "$catalog_domain" \
+    --arg registry_host "$registry_host" \
+    --arg proxy_host "$proxy_host" \
+    --arg route53_zone_id "$zone_id" \
+    '{aws_account_id: $aws_account_id, aws_region: $aws_region,
+      domains: [$catalog_domain, $registry_host, $proxy_host],
+      route53_validation_records_creation_enabled: true,
+      route53_zone_id: $route53_zone_id,
+      certificate_validation_wait_enabled: true}')
+
+  echo "Creating rvn-acm-certificate instance (blocks until DNS-validated)..." >&2
+  cert_instance_id=$(run_ravion_create "${given_id_prefix}-cert" "Quilt ACM certificate" rvn-acm-certificate "$cert_environment_id" "$cert_input" | jq -r '.id')
+  echo "  -> $cert_instance_id" >&2
+fi
+
+quilt_input=$(jq -n \
+  --arg name "$name" \
+  --arg template_url "$template_url" \
+  --arg catalog_domain "$catalog_domain" \
+  --arg admin_email "$admin_email" \
+  --arg sizing "$sizing" \
+  --arg aws_account_id "$quilt_account_id" \
+  --arg aws_region "$quilt_region" \
+  --arg certificate "$cert_instance_id" \
+  --arg dns "$dns_instance_id" \
+  '{name: $name, template_url: $template_url, catalog_domain: $catalog_domain,
+    admin_email: $admin_email, sizing: $sizing, aws_account_id: $aws_account_id,
+    aws_region: $aws_region, certificate: $certificate, dns: $dns}')
+
+echo "Creating quilt-catalog instance..." >&2
+quilt_instance_id=$(run_ravion_create "$given_id_prefix" "Customer Quilt deployment" quilt-catalog "$quilt_environment_id" "$quilt_input" | jq -r '.id')
+echo "  -> $quilt_instance_id" >&2
+
+cat <<EOF
+
+Done.
+  dns instance:   $dns_instance_id
+  cert instance:  $cert_instance_id
+  quilt instance: $quilt_instance_id
+  quilt_url:      https://$catalog_domain
+EOF


### PR DESCRIPTION
## Summary

- Adds `examples/ravion/` with `module.yaml`, a Ravion module definition that wraps `modules/quilt` and `modules/cnames` **unmodified** — same `provider`/`module "quilt"`/`parameters` pattern as `examples/main.tf`.
- Certificate and DNS are composed via typed `$ref` inputs (`certificate_ref`, `dns_ref`) rather than hand-copied ARNs/zone IDs.
- Derives Quilt's full hostname contract (catalog + registry + s3-proxy) in `main.tf`'s `local.hostnames`/`hostnames` output, so Ravion can validate the referenced certificate's SAN coverage before `apply`.
- CloudFormation template is fetched at plan/apply time via `template_url` — nothing generated or internal is committed to the repo.
- `README.md` documents the wrapper pattern and the cross-account composition case (deploying account ≠ domain-owning account).

Closes #126.

## Test plan

- [x] `terraform init -backend=false` + `terraform validate` pass in `examples/ravion/`
- [ ] Reviewed by someone with current Ravion module-schema access, since `module.yaml`'s exact field names/types are inferred from the issue's evaluation notes rather than verified against live Ravion docs
- [ ] Dry-run through an actual Ravion-connected account, per the issue's acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)